### PR TITLE
Updates info.plist camera privacy prompt

### DIFF
--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>This application will use the camera for Augmented Reality.</string>
+	<string>The Vocable app uses Apple&apos;s ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>The Vocable app uses Apple&apos;s ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
+	<string>The Vocable app uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Vocable uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
+	<string>Vocable uses ARKit head tracking to detect the user's face as seen in the device's TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>The Vocable app uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
+	<string>The Vocable app uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permission to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>The Vocable app uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permission to use the camera for this purpose.</string>
+	<string>Vocable uses ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. Vocable needs permission to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/EyeSpeak/Supporting Files/Info.plist
+++ b/EyeSpeak/Supporting Files/Info.plist
@@ -23,7 +23,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>The Vocable app uses Apple&apos;s ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
+	<string>The Vocable app uses Apple&apos;s ARKit head tracking to detect the user&apos;s face as seen in the device&apos;s TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permision to use the camera for this purpose.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Update as follows:

The Vocable app uses ARKit head tracking to detect the user's face as seen in the device's TrueDepth front camera feed for the purpose of controlling an on-screen pointer, allowing users with limited mobility to interact with the app. Head orientation and position data is used expressly for controlling the on-screen pointer. That head tracking data is not stored or transmitted in any way. The Vocable app needs permission to use the camera for this purpose.

As per request from Apple during app review: 

Guideline 2.1 - Information Needed
We have started the review of your app, but we are not able to continue because we need additional information about how your app uses information collected by the TrueDepth API.
Next Steps
To help us proceed with the review of your app, please provide complete and detailed information to the following questions.
• What information is your app collecting using the TrueDepth API?
• For what purposes are you collecting this information? Please provide a complete and clear explanation of all planned uses of this data.
• Will the data be shared with any third parties? Where will this information be stored?
Once you reply to this message in Resolution Center with the requested information, we can proceed with your review.
Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage
We noticed that your app requests the user's consent to access their camera but does not clarify the use of the camera in the applicable purpose string.
Next Steps
Please revise the relevant purpose string in your app's Info.plist file to specify why the app is requesting access to the user's camera. You can modify your app's Info.plist file using the property list editor in Xcode.
To help users understand why your app is requesting access to their personal data, all permission request alerts in your app should specify how your app will use the requested feature.
Resources
For additional information and instructions on requesting permission, please review the Requesting Permission section of the iOS Human Interface Guidelines and the Information Property List Key Reference. You may also want to review the Technical Q&A QA1937: Resolving the Privacy-Sensitive Data App Rejection page for details on how to provide a usage description for permission request alerts.
Please see attached screenshot for details.