### PR TITLE
Add setting to use built-in keyboard by default

### DIFF
--- a/Vocable/AppConfig/AppConfig.swift
+++ b/Vocable/AppConfig/AppConfig.swift
@@ -20,6 +20,7 @@ extension UserDefaultsKey {
     static let dwellDuration: UserDefaultsKey = "dwellDuration"
     static let isHeadTrackingEnabled: UserDefaultsKey = "isHeadTrackingEnabled"
     static let isCompactQWERTYKeyboardEnabled: UserDefaultsKey = "isCompactQWERTYKeyboardEnabled"
+    static let isBuiltInKeyboardEnabled: UserDefaultsKey = "isBuiltInKeyboardEnabled"
     static let selectedVoiceIdentifier: UserDefaultsKey = "selectedVoiceIdentifier"
 }
 
@@ -54,6 +55,9 @@ struct AppConfig {
 
     @PublishedDefault(.isCompactQWERTYKeyboardEnabled)
     static var isCompactQWERTYKeyboardEnabled: Bool = false
+
+    @PublishedDefault(.isBuiltInKeyboardEnabled)
+    static var isBuiltInKeyboardEnabled: Bool = false
     
     @PublishedDefault(.selectedVoiceIdentifier)
     static var selectedVoiceIdentifier: String? = .none

--- a/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
+++ b/Vocable/Features/Settings/SelectionMode/SelectionModeViewController.swift
@@ -13,6 +13,7 @@ final class SelectionModeViewController: VocableCollectionViewController {
     private enum SelectionModeItem: Int {
         case headTrackingToggle
         case compactQWERTY
+        case useBuiltInKeyboard
     }
 
     private enum SupplementaryKind: String {
@@ -53,7 +54,7 @@ final class SelectionModeViewController: VocableCollectionViewController {
     private func updateDataSource(animated: Bool = false) {
         var snapshot = Snapshot()
         snapshot.appendSections([.headTracking])
-        snapshot.appendItems([.headTrackingToggle])
+        snapshot.appendItems([.headTrackingToggle, .useBuiltInKeyboard])
         if AppConfig.isHeadTrackingEnabled {
             snapshot.appendItems([.compactQWERTY])
         }
@@ -93,6 +94,14 @@ final class SelectionModeViewController: VocableCollectionViewController {
                     accessibilityIdentifier: .settings.selectionMode.compactQwertyToggle
                 ) { [weak self] in
                     self?.toggleCompactQwerty()
+                }
+            case .useBuiltInKeyboard:
+                cell.contentConfiguration = VocableListContentConfiguration.toggleCell(
+                    title: String(localized: "settings.cell.use_builtin_keyboard.title"),
+                    isOn: AppConfig.isBuiltInKeyboardEnabled,
+                    accessibilityIdentifier: .settings.selectionMode.useBuiltInKeyboardToggle
+                ) { [weak self] in
+                    self?.toggleUseBuiltInKeyboard()
                 }
             }
         }
@@ -192,7 +201,7 @@ final class SelectionModeViewController: VocableCollectionViewController {
     func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
             guard let item = dataSource.itemIdentifier(for: indexPath) else { return false }
             return switch item {
-            case .compactQWERTY: true
+            case .compactQWERTY, .useBuiltInKeyboard: true
             case .headTrackingToggle: AppConfig.isHeadTrackingSupported
             }
         }
@@ -200,7 +209,7 @@ final class SelectionModeViewController: VocableCollectionViewController {
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return false }
         return switch item {
-        case .compactQWERTY: true
+        case .compactQWERTY, .useBuiltInKeyboard: true
         case .headTrackingToggle: AppConfig.isHeadTrackingSupported
         }
     }
@@ -210,6 +219,11 @@ final class SelectionModeViewController: VocableCollectionViewController {
     private func toggleCompactQwerty() {
         AppConfig.isCompactQWERTYKeyboardEnabled.toggle()
         dataSource.reloadItem(.compactQWERTY, animated: false)
+    }
+
+    private func toggleUseBuiltInKeyboard() {
+        AppConfig.isBuiltInKeyboardEnabled.toggle()
+        dataSource.reloadItem(.useBuiltInKeyboard, animated: false)
     }
 
     private func toggleHeadTracking() {

--- a/Vocable/Features/TextEditor/TextEditorViewController.swift
+++ b/Vocable/Features/TextEditor/TextEditorViewController.swift
@@ -43,7 +43,7 @@ class TextEditorViewController: VocableViewController, UICollectionViewDelegate,
     // Single source of truth for the state of edited text
     private var textTransaction = TextTransaction(text: "") {
         didSet {
-            if textView.attributedText?.string != textTransaction.attributedText.string {
+            if textView.attributedText != textTransaction.attributedText {
                 let selectedRange = textView.selectedRange
                 textView.attributedText = textTransaction.attributedText
                 textView.selectedRange = selectedRange

--- a/Vocable/Features/TextEditor/TextEditorViewController.swift
+++ b/Vocable/Features/TextEditor/TextEditorViewController.swift
@@ -43,7 +43,11 @@ class TextEditorViewController: VocableViewController, UICollectionViewDelegate,
     // Single source of truth for the state of edited text
     private var textTransaction = TextTransaction(text: "") {
         didSet {
-            textView.attributedText = textTransaction.attributedText
+            if textView.attributedText?.string != textTransaction.attributedText.string {
+                let selectedRange = textView.selectedRange
+                textView.attributedText = textTransaction.attributedText
+                textView.selectedRange = selectedRange
+            }
             updateSuggestions(textTransaction)
             delegate?.textEditorViewController(self, textDidChange: self.text)
         }
@@ -118,17 +122,39 @@ class TextEditorViewController: VocableViewController, UICollectionViewDelegate,
         navigationBar.leftButton = leftButton
         navigationBar.rightButton = rightButton
 
+        configureKeyboardMode()
+
         setNeedsUpdateConfiguration()
+    }
+
+    private func configureKeyboardMode() {
+        if AppConfig.isBuiltInKeyboardEnabled {
+            keyboardView.isHidden = true
+            textView.isEditable = true
+            textView.isSelectable = true
+            textView.isUserInteractionEnabled = true
+            textView.delegate = self
+        } else {
+            keyboardView.isHidden = false
+            textView.isEditable = false
+            textView.isSelectable = false
+            textView.isUserInteractionEnabled = false
+            textView.delegate = nil
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        configureKeyboardMode()
         textTransaction = TextTransaction(text: delegate?.textEditorViewControllerInitialValue(self) ?? "", intent: .lastCharacter)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         (view.window as? HeadGazeWindow)?.cancelActiveGazeTarget()
+        if AppConfig.isBuiltInKeyboardEnabled {
+            textView.becomeFirstResponder()
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -251,6 +277,17 @@ class TextEditorViewController: VocableViewController, UICollectionViewDelegate,
             }
         case .numberPad, .alphabet, .openModifierPicker, .closeModifierPicker, .beginModifier, .endModifier:
             break
+        }
+    }
+}
+
+extension TextEditorViewController: UITextViewDelegate {
+
+    func textViewDidChange(_ textView: UITextView) {
+        guard AppConfig.isBuiltInKeyboardEnabled else { return }
+        let newText = textView.text ?? ""
+        if newText != textTransaction.text {
+            textTransaction = TextTransaction(text: newText, intent: .lastCharacter)
         }
     }
 }

--- a/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Settings+SelectionMode.swift
+++ b/Vocable/Supporting Files/AXIdentifier/AccessibilityID+Settings+SelectionMode.swift
@@ -12,6 +12,7 @@ extension AccessibilityID.settings {
     public struct selectionMode {
         public static let headTrackingToggle: AccessibilityID = "selection-mode-head-tracking-toggle"
         public static let compactQwertyToggle: AccessibilityID = "selection-mode-compact-qwerty-toggle"
+        public static let useBuiltInKeyboardToggle: AccessibilityID = "selection-mode-use-builtin-keyboard-toggle"
         private init() {}
     }
 }

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -10294,6 +10294,17 @@
           }
         }
       }
+    },
+    "settings.cell.use_builtin_keyboard.title" : {
+      "comment" : "Option within Selection Mode settings to enable or disable using the system built-in keyboard.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Built-in Keyboard"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Vocable/Supporting Files/Localizable.xcstrings
+++ b/Vocable/Supporting Files/Localizable.xcstrings
@@ -1,10311 +1,10383 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "categories_list_editor.header.title" : {
-      "comment" : "Categories Header title.  This appears in the Settings flow when navigating to the list of Categories",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تصنيف"
+  "sourceLanguage": "en",
+  "strings": {
+    "categories_list_editor.header.title": {
+      "comment": "Categories Header title.  This appears in the Settings flow when navigating to the list of Categories",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصنيف"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorier"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorier"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorien"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorien"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categories"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categorías"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorías"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catégories"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catégories"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रेणियाँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रेणियाँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categorie"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorie"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카테고리"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카테고리"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Категории"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Категории"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thể loại"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thể loại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "类别"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类别"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "目录"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目录"
           }
         }
       }
     },
-    "category_editor.alert.delete_category_confirmation.button.cancel.title" : {
-      "comment" : "Delete category alert cancel button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "category_editor.alert.delete_category_confirmation.button.cancel.title": {
+      "comment": "Delete category alert cancel button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "category_editor.alert.delete_category_confirmation.button.remove.title" : {
-      "comment" : "Delete category alert action button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أزِل"
+    "category_editor.alert.delete_category_confirmation.button.remove.title": {
+      "comment": "Delete category alert action button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أزِل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retirer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हटाना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हटाना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovere"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovere"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제거하다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거하다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loại bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loại bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "消除"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消除"
           }
         }
       }
     },
-    "category_editor.alert.delete_category_confirmation.title" : {
-      "comment" : "Delete category confirmation alert title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الفئات المحذوفة لا يمكن استردادها."
+    "category_editor.alert.delete_category_confirmation.title": {
+      "comment": "Delete category confirmation alert title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفئات المحذوفة لا يمكن استردادها."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slettede kategorier kan ikke blive gendannet."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slettede kategorier kan ikke blive gendannet."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gelöschte Kategorien können nicht wiederhergestellt werden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöschte Kategorien können nicht wiederhergestellt werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deleted categories cannot be recovered."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleted categories cannot be recovered."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las categorías eliminadas son irrecuperables."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las categorías eliminadas son irrecuperables."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les catégories supprimées ne peuvent pas être récupérées."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les catégories supprimées ne peuvent pas être récupérées."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हटाई गई श्रेणियां पुनर्प्राप्त नहीं की जा सकतीं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हटाई गई श्रेणियां पुनर्प्राप्त नहीं की जा सकतीं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le categorie eliminate non possono essere recuperate."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le categorie eliminate non possono essere recuperate."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "삭제된 카테고리는 복구할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제된 카테고리는 복구할 수 없습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удаленные категории не могут быть восстановлены."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удаленные категории не могут быть восстановлены."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể phục hồi các danh mục đã xóa."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể phục hồi các danh mục đã xóa."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除后的对话无法恢复。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除后的对话无法恢复。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清除了的類別不可以恢復的"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除了的類別不可以恢復的"
           }
         }
       }
     },
-    "category_editor.alert.delete_phrase_confirmation.button.cancel.title" : {
-      "comment" : "Delete phrase alert cancel button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "category_editor.alert.delete_phrase_confirmation.button.cancel.title": {
+      "comment": "Delete phrase alert cancel button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "category_editor.alert.delete_phrase_confirmation.button.delete.title" : {
-      "comment" : "Delete phrase alert action button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أزِل"
+    "category_editor.alert.delete_phrase_confirmation.button.delete.title": {
+      "comment": "Delete phrase alert action button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أزِل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retirer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हटाना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हटाना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovere"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovere"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제거하다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거하다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loại bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loại bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "消除"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消除"
           }
         }
       }
     },
-    "category_editor.alert.delete_phrase_confirmation.title" : {
-      "comment" : "Delete phrase confirmation alert title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فالعبارات التي يتم مسحها لا يمكن إسترجاعها."
+    "category_editor.alert.delete_phrase_confirmation.title": {
+      "comment": "Delete phrase confirmation alert title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فالعبارات التي يتم مسحها لا يمكن إسترجاعها."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slettede sætninger kan ikke genskabes."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slettede sætninger kan ikke genskabes."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gelöschte Sätze können nicht wiederhergestellt werden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelöschte Sätze können nicht wiederhergestellt werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deleted phrases cannot be recovered."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleted phrases cannot be recovered."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las frases eliminadas son irrecuperables."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las frases eliminadas son irrecuperables."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les phrases supprimées ne peuvent pas être récupérées."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les phrases supprimées ne peuvent pas être récupérées."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हटाए गए वाक्यांशों को पुनर्प्राप्त नहीं किया जा सकता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हटाए गए वाक्यांशों को पुनर्प्राप्त नहीं किया जा सकता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminati I Rischi Non Possono Essere Recuperati."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminati I Rischi Non Possono Essere Recuperati."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "삭제된 문구는 복구할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제된 문구는 복구할 수 없습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удаленные фразы не могут быть восстановлены."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удаленные фразы не могут быть восстановлены."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể khôi phục các cụm từ đã xóa."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể khôi phục các cụm từ đã xóa."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除后的对话无法恢复。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除后的对话无法恢复。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已刪除的類別無法恢復"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已刪除的類別無法恢復"
           }
         }
       }
     },
-    "category_editor.detail.button.edit_phrases.title" : {
-      "comment" : "Setting option for a category.  Navigates the user to a list of phrases within the category where the phrases can be deleted or edited.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحرير العبارات"
+    "category_editor.detail.button.edit_phrases.title": {
+      "comment": "Setting option for a category.  Navigates the user to a list of phrases within the category where the phrases can be deleted or edited.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير العبارات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rediger Sætninger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rediger Sætninger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sätze bearbeiten"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sätze bearbeiten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Phrases"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Phrases"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Editar Frases"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar Frases"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifier les phrases"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier les phrases"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक्यांश संपादित करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक्यांश संपादित करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica Frasi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica Frasi"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문구 편집"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문구 편집"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Редактировать фразы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редактировать фразы"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chỉnh sửa cụm từ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa cụm từ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "编辑对话"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑对话"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "編輯短語"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯短語"
           }
         }
       }
     },
-    "category_editor.detail.button.remove_category.title" : {
-      "comment" : "Setting option for a category.  Button that will delete the category.  Tapping the button will display an alert confirmation.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ازالة فئة"
+    "category_editor.detail.button.remove_category.title": {
+      "comment": "Setting option for a category.  Button that will delete the category.  Tapping the button will display an alert confirmation.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ازالة فئة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern Kategori"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fjern Kategori"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorie entfernen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie entfernen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove Category"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Category"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminar Categoría"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar Categoría"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer la catégorie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer la catégorie"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रेणी हटाएं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रेणी हटाएं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rimuovere la categoria"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovere la categoria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카테고리 제거"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카테고리 제거"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить категорию"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить категорию"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa danh mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa danh mục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除类别"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除类别"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刪除類別?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除類別?"
           }
         }
       }
     },
-    "category_editor.detail.button.rename_category.title" : {
-      "comment" : "Setting option for a category.  Navigates the user to a keyboard view where they can edit the Category name.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تسمية فئة"
+    "category_editor.detail.button.rename_category.title": {
+      "comment": "Setting option for a category.  Navigates the user to a keyboard view where they can edit the Category name.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تسمية فئة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omdøb kategori"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omdøb kategori"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorie umbenennen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie umbenennen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rename Category"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Category"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar Nombre de Categoría"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar Nombre de Categoría"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renommer la catégorie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renommer la catégorie"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रेणी का नाम बदलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रेणी का नाम बदलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rinomina Categoria"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rinomina Categoria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "범주 이름 바꾸기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "범주 이름 바꾸기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переименовать категорию"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переименовать категорию"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đổi tên danh mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đổi tên danh mục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名类别"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名类别"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重命名類別"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重命名類別"
           }
         }
       }
     },
-    "category_editor.detail.button.show_category.title" : {
-      "comment" : "Toggle option for a category within settings.  Can be toggled on or off to hide or show the category in the main view.  Hiding the category will also move the category in settings to the end of the list.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إظهار الفئة"
+    "category_editor.detail.button.show_category.title": {
+      "comment": "Toggle option for a category within settings.  Can be toggled on or off to hide or show the category in the main view.  Hiding the category will also move the category in settings to the end of the list.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الفئة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vis kategori"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis kategori"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorie anzeigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorie anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Category"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Category"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar categoría"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar categoría"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Montrer la catégorie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Montrer la catégorie"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रेणी दिखाएँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रेणी दिखाएँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra categoria"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra categoria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카테고리 표시"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카테고리 표시"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать категорию"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать категорию"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiển thị danh mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị danh mục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示分类名称"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示分类名称"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示類別"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示類別"
           }
         }
       }
     },
-    "category_editor.toast.changes_saved.title" : {
-      "comment" : "changes to an existing phrase were saved successfully",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم حفظ التغييرات"
+    "category_editor.toast.changes_saved.title": {
+      "comment": "changes to an existing phrase were saved successfully",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم حفظ التغييرات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dine ændringer er gemt"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dine ændringer er gemt"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Änderungen gespeichert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen gespeichert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changes saved"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes saved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambios guardados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios guardados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changements sauvegardés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changements sauvegardés"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "परिवर्तन सहेजा गया!"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "परिवर्तन सहेजा गया!"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifiche salvate"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifiche salvate"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "변경사항이 저장됨"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경사항이 저장됨"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменения сохранены"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменения сохранены"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Các thay đổi đã được lưu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các thay đổi đã được lưu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已保存更改"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存更改"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改已儲存"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改已儲存"
           }
         }
       }
     },
-    "category_editor.toast.successfully_saved.title" : {
-      "comment" : "Toast message that appears after saving edits made to the Category title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم حفظ التغييرات"
+    "category_editor.toast.successfully_saved.title": {
+      "comment": "Toast message that appears after saving edits made to the Category title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم حفظ التغييرات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dine ændringer er gemt"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dine ændringer er gemt"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Änderungen gespeichert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen gespeichert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changes Saved"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes Saved"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambios guardados"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios guardados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changements sauvegardés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changements sauvegardés"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "बदलाव सुरक्षित किया गया"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बदलाव सुरक्षित किया गया"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifiche salvate"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifiche salvate"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "변경 사항 저장"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경 사항 저장"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменения сохранены"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменения сохранены"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Các thay đổi đã được lưu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các thay đổi đã được lưu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改已保存"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改已保存"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改已儲存"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改已儲存"
           }
         }
       }
     },
-    "empty_state.button.title" : {
-      "comment" : "Category empty state button.  This button appears with the empty state to allow the user to add a phrase",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أضف عبارة"
+    "empty_state.button.title": {
+      "comment": "Category empty state button.  This button appears with the empty state to allow the user to add a phrase",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضف عبارة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilføj sætning"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilføj sætning"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Satz hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Satz hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Phrase"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar frase"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar frase"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter une expression"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une expression"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक्यांश जोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक्यांश जोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi frase"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi frase"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구문 추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구문 추가"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить фразу"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить фразу"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm cụm từ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thêm cụm từ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加短语"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加短语"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加短語"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加短語"
           }
         }
       }
     },
-    "empty_state.header.title" : {
-      "comment" : "Category empty state.  This empty state appears when there are no phrases in the category in both the main screen and settings screen.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لم يتم حفظ أي عبارات حتى الآن."
+    "empty_state.header.title": {
+      "comment": "Category empty state.  This empty state appears when there are no phrases in the category in both the main screen and settings screen.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم حفظ أي عبارات حتى الآن."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen sætninger er blevet gemt endnu."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen sætninger er blevet gemt endnu."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es wurden noch keine Phrasen gespeichert."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es wurden noch keine Phrasen gespeichert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No phrases have been saved yet."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No phrases have been saved yet."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aún no se han guardado frases."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no se han guardado frases."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune phrase n'a encore été enregistrée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune phrase n'a encore été enregistrée."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अभी तक कोई वाक्यांश सहेजा नहीं गया है."
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अभी तक कोई वाक्यांश सहेजा नहीं गया है."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna frase è stata ancora salvata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna frase è stata ancora salvata."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아직 저장된 문구가 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 저장된 문구가 없습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ни одна фраза еще не сохранена."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ни одна фраза еще не сохранена."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chưa có cụm từ nào được lưu."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa có cụm từ nào được lưu."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尚未保存任何短语。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未保存任何短语。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尚未儲存任何短語。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未儲存任何短語。"
           }
         }
       }
     },
-    "gaze_settings.alert.disable_head_tracking_confirmation.button.cancel.title" : {
-      "comment" : "Cancel alert action title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "gaze_settings.alert.disable_head_tracking_confirmation.button.cancel.title": {
+      "comment": "Cancel alert action title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "gaze_settings.alert.disable_head_tracking_confirmation.button.confirm.title" : {
-      "comment" : "Confirm alert action title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استمر"
+    "gaze_settings.alert.disable_head_tracking_confirmation.button.confirm.title": {
+      "comment": "Confirm alert action title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استمر"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forsæt"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forsæt"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जारी रखना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जारी रखना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계속하다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속하다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếp tục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繼續"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續"
           }
         }
       }
     },
-    "gaze_settings.alert.disable_head_tracking_confirmation.title" : {
-      "comment" : "Disable head tracking confirmation alert title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "سيؤدي إيقاف تشغيل تتبع الرأس إلى جعل Vocable يعمل باللمس فقط. هل ترغب في الاستمرار؟"
+    "gaze_settings.alert.disable_head_tracking_confirmation.title": {
+      "comment": "Disable head tracking confirmation alert title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سيؤدي إيقاف تشغيل تتبع الرأس إلى جعل Vocable يعمل باللمس فقط. هل ترغب في الاستمرار؟"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "At slå hovedsporing fra vil gøre Vocable touch-kun. Vil du fortsætte?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "At slå hovedsporing fra vil gøre Vocable touch-kun. Vil du fortsætte?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie die Kopfverfolgung deaktivieren, ist Vocable nur noch berührungsempfindlich. Möchten Sie fortfahren?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie die Kopfverfolgung deaktivieren, ist Vocable nur noch berührungsempfindlich. Möchten Sie fortfahren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Turning off head tracking will make Vocable touch-only. Would you like to continue?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turning off head tracking will make Vocable touch-only. Would you like to continue?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivar el seguimiento de la cabeza hará que Vocable sea solo táctil. ¿Te gustaria continuar?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar el seguimiento de la cabeza hará que Vocable sea solo táctil. ¿Te gustaria continuar?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactiver le suivi de la tête rendra la Vocable uniquement au toucher. Voulez-vous continuer ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactiver le suivi de la tête rendra la Vocable uniquement au toucher. Voulez-vous continuer ?"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हेड ट्रैकिंग बंद करने से वोकेबल केवल टच-ओनली हो जाएगा। क्या आप जारी रखना चाहेंगे?"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हेड ट्रैकिंग बंद करने से वोकेबल केवल टच-ओनली हो जाएगा। क्या आप जारी रखना चाहेंगे?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La disattivazione del tracciamento della testa renderà Vocable solo touch. Vuoi continuare?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La disattivazione del tracciamento della testa renderà Vocable solo touch. Vuoi continuare?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "머리 추적을 끄면 Vocable은 터치 전용이 됩니다. 계속하시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "머리 추적을 끄면 Vocable은 터치 전용이 됩니다. 계속하시겠습니까?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отключение отслеживания головы сделает Vocable доступным только для сенсорного управления. Желаете ли вы продолжить?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключение отслеживания головы сделает Vocable доступным только для сенсорного управления. Желаете ли вы продолжить?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tắt tính năng theo dõi đầu sẽ khiến Vocable chỉ có cảm ứng. Bạn có muốn tiếp tục không?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt tính năng theo dõi đầu sẽ khiến Vocable chỉ có cảm ứng. Bạn có muốn tiếp tục không?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭头部追踪将使 Vocable 只能进行触摸操作。 你想继续吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭头部追踪将使 Vocable 只能进行触摸操作。 你想继续吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉頭部追蹤將使 Vocable 只能進行觸控操作。 你想繼續嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉頭部追蹤將使 Vocable 只能進行觸控操作。 你想繼續嗎？"
           }
         }
       }
     },
-    "gaze_tracking.error.excessive_head_distance.title" : {
-      "comment" : "Warning message presented to the user when the head tracking system",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "من فضلك إقترب أكثر من الجهاز."
+    "gaze_tracking.error.excessive_head_distance.title": {
+      "comment": "Warning message presented to the user when the head tracking system",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "من فضلك إقترب أكثر من الجهاز."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kom nærmere din mobilenhed."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kom nærmere din mobilenhed."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte näher ans Gerät kommen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte näher ans Gerät kommen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please move closer to the device."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please move closer to the device."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acérquese al dispositivo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acérquese al dispositivo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez vous rapprocher du périphérique."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veuillez vous rapprocher du périphérique."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कृपया डिवाइस के करीब जाएं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कृपया डिवाइस के करीब जाएं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvicinati al dispositivo per favore."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avvicinati al dispositivo per favore."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기기에 가까이 오세요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기기에 가까이 오세요"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пожалуйста, подойдите ближе к устройству."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожалуйста, подойдите ближе к устройству."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vui lòng di chuyển đến gần thiết bị hơn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vui lòng di chuyển đến gần thiết bị hơn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请靠近设备"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请靠近设备"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請靠近設備。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請靠近設備。"
           }
         }
       }
     },
-    "listening_mode.empty_state.actively_listening.message" : {
-      "comment" : "Listening mode empty state message for when listening has began but no responses have been displayed yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عندما يسأل شخص ما سؤالاً بصوت عالٍ ، سيقدم Vocable خيارات استجابة سريعة."
+    "listening_mode.empty_state.actively_listening.message": {
+      "comment": "Listening mode empty state message for when listening has began but no responses have been displayed yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عندما يسأل شخص ما سؤالاً بصوت عالٍ ، سيقدم Vocable خيارات استجابة سريعة."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Når nogen stiller et spørgsmål højt, vil Vocable tilbyde hurtige svarmuligheder."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Når nogen stiller et spørgsmål højt, vil Vocable tilbyde hurtige svarmuligheder."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn jemand eine Frage laut stellt, bietet Vocable schnelle Antwortmöglichkeiten."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn jemand eine Frage laut stellt, bietet Vocable schnelle Antwortmöglichkeiten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When someone asks a question out loud, Vocable will offer quick response options."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When someone asks a question out loud, Vocable will offer quick response options."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cuando alguien hace una pregunta en voz alta, Vocable ofrecerá opciones de respuesta rápidas."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando alguien hace una pregunta en voz alta, Vocable ofrecerá opciones de respuesta rápidas."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lorsque quelqu'un pose une question à voix haute, Vocable offre des options de réponse rapide."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lorsque quelqu'un pose une question à voix haute, Vocable offre des options de réponse rapide."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जब कोई ज़ोर से कोई प्रश्न पूछता है, तो वोकेबल त्वरित प्रतिक्रिया विकल्प प्रदान करेगा।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जब कोई ज़ोर से कोई प्रश्न पूछता है, तो वोकेबल त्वरित प्रतिक्रिया विकल्प प्रदान करेगा।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quando qualcuno fa una domanda ad alta voce, Vocable offrirà opzioni di risposta rapida."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quando qualcuno fa una domanda ad alta voce, Vocable offrirà opzioni di risposta rapida."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "누군가 큰 소리로 질문하면 Vocable은 빠른 응답 옵션을 제공합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "누군가 큰 소리로 질문하면 Vocable은 빠른 응답 옵션을 제공합니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Когда кто-то задает вопрос вслух, Vocable предложит варианты быстрого ответа."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Когда кто-то задает вопрос вслух, Vocable предложит варианты быстрого ответа."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khi ai đó hỏi to một câu hỏi, Vocable sẽ cung cấp các tùy chọn trả lời nhanh."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khi ai đó hỏi to một câu hỏi, Vocable sẽ cung cấp các tùy chọn trả lời nhanh."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当有人大声提出问题时，Vocable 将提供快速响应选项。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当有人大声提出问题时，Vocable 将提供快速响应选项。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "當有人大聲提出問題時，Vocable 將提供快速響應選項。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "當有人大聲提出問題時，Vocable 將提供快速響應選項。"
           }
         }
       }
     },
-    "listening_mode.empty_state.actively_listening.title" : {
-      "comment" : "Listening mode empty state title for when listening has began but no responses have been displayed yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جار الاستماع..."
+    "listening_mode.empty_state.actively_listening.title": {
+      "comment": "Listening mode empty state title for when listening has began but no responses have been displayed yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جار الاستماع..."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lytter..."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lytter..."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuhören ..."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuhören ..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escuchando..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escuchando..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En écoute..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En écoute..."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सुन रहें है..."
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुन रहें है..."
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In ascolto..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In ascolto..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "청취..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "청취..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Слушаю..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слушаю..."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang nghe..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang nghe..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在聆听…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在聆听…"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在聆聽..."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在聆聽..."
           }
         }
       }
     },
-    "listening_mode.empty_state.free_response.message" : {
-      "comment" : "Listen mode empty state message for when no responses could be generated",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لست متأكدا ما أقترحه. يرجى استخدام لوحة المفاتيح أو تحديد عبارة موجودة للرد عليها."
+    "listening_mode.empty_state.free_response.message": {
+      "comment": "Listen mode empty state message for when no responses could be generated",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لست متأكدا ما أقترحه. يرجى استخدام لوحة المفاتيح أو تحديد عبارة موجودة للرد عليها."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ikke sikker på hvad du skal foreslå. Brug tastaturet eller vælg en eksisterende sætning for at svare."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ikke sikker på hvad du skal foreslå. Brug tastaturet eller vælg en eksisterende sætning for at svare."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht sicher, was Sie vorschlagen sollen. Bitte verwenden Sie die Tastatur oder wählen Sie eine bestehende Phrase, um zu antworten."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht sicher, was Sie vorschlagen sollen. Bitte verwenden Sie die Tastatur oder wählen Sie eine bestehende Phrase, um zu antworten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not sure what to suggest. Please use the keyboard or select an existing phrase to reply."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not sure what to suggest. Please use the keyboard or select an existing phrase to reply."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No está seguro de qué sugerir. Utilice el teclado o seleccione una frase existente para responder."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No está seguro de qué sugerir. Utilice el teclado o seleccione una frase existente para responder."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je ne sais pas quoi suggérer. Veuillez utiliser le clavier ou sélectionner une phrase existante pour répondre."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je ne sais pas quoi suggérer. Veuillez utiliser le clavier ou sélectionner une phrase existante pour répondre."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सुनिश्चित नहीं है कि क्या सुझाव देना है। कृपया कीबोर्ड का उपयोग करें या उत्तर देने के लिए किसी मौजूदा वाक्यांश का चयन करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनिश्चित नहीं है कि क्या सुझाव देना है। कृपया कीबोर्ड का उपयोग करें या उत्तर देने के लिए किसी मौजूदा वाक्यांश का चयन करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è sicuro di cosa suggerire. Si prega di utilizzare la tastiera o selezionare una frase esistente per rispondere."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non è sicuro di cosa suggerire. Si prega di utilizzare la tastiera o selezionare una frase esistente per rispondere."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "무엇을 제안해야 할지 잘 모르겠습니다. 키보드를 사용하거나 기존 문구를 선택하여 답장을 보내주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "무엇을 제안해야 할지 잘 모르겠습니다. 키보드를 사용하거나 기존 문구를 선택하여 답장을 보내주세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не уверен, что предложить. Пожалуйста, используйте клавиатуру или выберите существующую фразу, чтобы ответить."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не уверен, что предложить. Пожалуйста, используйте клавиатуру или выберите существующую фразу, чтобы ответить."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không chắc chắn những gì để đề xuất. Vui lòng sử dụng bàn phím hoặc chọn một cụm từ hiện có để trả lời."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không chắc chắn những gì để đề xuất. Vui lòng sử dụng bàn phím hoặc chọn một cụm từ hiện có để trả lời."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不知道要建议什么。请使用键盘或选择一个现有的短语来回复。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不知道要建议什么。请使用键盘或选择一个现有的短语来回复。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不知道該建議什麼。請使用鍵盤或選擇現有短語進行回复。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不知道該建議什麼。請使用鍵盤或選擇現有短語進行回复。"
           }
         }
       }
     },
-    "listening_mode.empty_state.free_response.title" : {
-      "comment" : "Listen mode empty state title for when no responses could be generated",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبدو معقدة"
+    "listening_mode.empty_state.free_response.title": {
+      "comment": "Listen mode empty state title for when no responses could be generated",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبدو معقدة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyde kompliceret"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyde kompliceret"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klingt kompliziert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klingt kompliziert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sounds complicated"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sounds complicated"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suena complicado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suena complicado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela semble compliqué"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela semble compliqué"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जटिल लगता है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जटिल लगता है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suoni complicati"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suoni complicati"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복잡하게 들린다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복잡하게 들린다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Звучит сложно"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Звучит сложно"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nghe có vẻ phức tạp"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nghe có vẻ phức tạp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "听起来很复杂"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "听起来很复杂"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聽起來很複雜"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聽起來很複雜"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_denied.action" : {
-      "comment" : "Listen mode empty state action that will allow the user to open the Settings app in order to grant microphone permissions.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح الإعدادات"
+    "listening_mode.empty_state.microphone_permission_denied.action": {
+      "comment": "Listen mode empty state action that will allow the user to open the Settings app in order to grant microphone permissions.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir configuración"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les paramètres"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स खोलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть настройки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開設置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開設置"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_denied.message" : {
-      "comment" : "Listening mode empty state message for when microphone permissions are required, but the user has denied them",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج Vocable إلى استخدام الميكروفون لتمكين وضع الاستماع. يرجى السماح بالوصول إلى الميكروفون في إعدادات %1$@.\n\nيمكنك أيضًا تعطيل وضع الاستماع لإخفاء هذه الفئة."
+    "listening_mode.empty_state.microphone_permission_denied.message": {
+      "comment": "Listening mode empty state message for when microphone permissions are required, but the user has denied them",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج Vocable إلى استخدام الميكروفون لتمكين وضع الاستماع. يرجى السماح بالوصول إلى الميكروفون في إعدادات %1$@.\n\nيمكنك أيضًا تعطيل وضع الاستماع لإخفاء هذه الفئة."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable skal bruge mikrofonen for at aktivere Lytningstilstand. Tillad venligst mikrofonadgang i %1$@ indstillinger.\n\nDu kan også deaktivere Lytningstilstand for at skjule denne kategori."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable skal bruge mikrofonen for at aktivere Lytningstilstand. Tillad venligst mikrofonadgang i %1$@ indstillinger.\n\nDu kan også deaktivere Lytningstilstand for at skjule denne kategori."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable muss das Mikrofon verwenden, um den Hörmodus zu aktivieren. Bitte erlauben Sie den Mikrofonzugriff in den %1$@-Einstellungen.\n\nSie können den Hörmodus auch deaktivieren, um diese Kategorie auszublenden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable muss das Mikrofon verwenden, um den Hörmodus zu aktivieren. Bitte erlauben Sie den Mikrofonzugriff in den %1$@-Einstellungen.\n\nSie können den Hörmodus auch deaktivieren, um diese Kategorie auszublenden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable needs to use the microphone to enable Listening Mode. Please allow microphone access in %1$@ Settings.\n\nYou can also disable Listening Mode to hide this category."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable needs to use the microphone to enable Listening Mode. Please allow microphone access in %1$@ Settings.\n\nYou can also disable Listening Mode to hide this category."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necesita usar el micrófono para habilitar el modo de escucha. Permita el acceso al micrófono en %1$@ Configuración.\n\nTambién puedes desactivar el modo de escucha para ocultar esta categoría."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necesita usar el micrófono para habilitar el modo de escucha. Permita el acceso al micrófono en %1$@ Configuración.\n\nTambién puedes desactivar el modo de escucha para ocultar esta categoría."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable doit utiliser le microphone pour activer le mode d'écoute. Veuillez autoriser l'accès au microphone dans %1$@ Paramètres.\n\nVous pouvez également désactiver le mode d'écoute pour masquer cette catégorie."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable doit utiliser le microphone pour activer le mode d'écoute. Veuillez autoriser l'accès au microphone dans %1$@ Paramètres.\n\nVous pouvez également désactiver le mode d'écoute pour masquer cette catégorie."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "लिसनिंग मोड को सक्षम करने के लिए वोकेबल को माइक्रोफ़ोन का उपयोग करने की आवश्यकता है। कृपया %1$@ सेटिंग्स में माइक्रोफ़ोन एक्सेस की अनुमति दें।\n\nइस श्रेणी को छिपाने के लिए आप श्रवण मोड को भी अक्षम कर सकते हैं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लिसनिंग मोड को सक्षम करने के लिए वोकेबल को माइक्रोफ़ोन का उपयोग करने की आवश्यकता है। कृपया %1$@ सेटिंग्स में माइक्रोफ़ोन एक्सेस की अनुमति दें।\n\nइस श्रेणी को छिपाने के लिए आप श्रवण मोड को भी अक्षम कर सकते हैं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable deve utilizzare il microfono per abilitare la modalità di ascolto. Consenti l'accesso al microfono nelle Impostazioni %1$@.\n\nPuoi anche disattivare la modalità di ascolto per nascondere questa categoria."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable deve utilizzare il microfono per abilitare la modalità di ascolto. Consenti l'accesso al microfono nelle Impostazioni %1$@.\n\nPuoi anche disattivare la modalità di ascolto per nascondere questa categoria."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable은 청취 모드를 활성화하려면 마이크를 사용해야 합니다. %1$@ 설정에서 마이크 액세스를 허용해 주세요.\n\n청취 모드를 비활성화하여 이 카테고리를 숨길 수도 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable은 청취 모드를 활성화하려면 마이크를 사용해야 합니다. %1$@ 설정에서 마이크 액세스를 허용해 주세요.\n\n청취 모드를 비활성화하여 이 카테고리를 숨길 수도 있습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable необходимо использовать микрофон, чтобы включить режим прослушивания. Разрешите доступ к микрофону в настройках %1$@.\n\nВы также можете отключить режим прослушивания, чтобы скрыть эту категорию."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable необходимо использовать микрофон, чтобы включить режим прослушивания. Разрешите доступ к микрофону в настройках %1$@.\n\nВы также можете отключить режим прослушивания, чтобы скрыть эту категорию."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable cần sử dụng micrô để bật Chế độ nghe. Vui lòng cho phép truy cập micrô trong Cài đặt %1$@.\n\nBạn cũng có thể tắt Chế độ nghe để ẩn danh mục này."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable cần sử dụng micrô để bật Chế độ nghe. Vui lòng cho phép truy cập micrô trong Cài đặt %1$@.\n\nBạn cũng có thể tắt Chế độ nghe để ẩn danh mục này."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要使用麦克风来启用聆听模式。 请在%1$@ 设置中允许麦克风访问。\n\n您还可以禁用聆听模式来隐藏此类别。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要使用麦克风来启用聆听模式。 请在%1$@ 设置中允许麦克风访问。\n\n您还可以禁用聆听模式来隐藏此类别。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要使用麥克風來啟用聆聽模式。 請在%1$@ 設定中允許麥克風存取。\n\n您也可以停用聆聽模式來隱藏此類別。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要使用麥克風來啟用聆聽模式。 請在%1$@ 設定中允許麥克風存取。\n\n您也可以停用聆聽模式來隱藏此類別。"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_denied.title" : {
-      "comment" : "Listening mode empty state title for when microphone permissions are required, but the user has denied them",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوصول إلى الميكروفون"
+    "listening_mode.empty_state.microphone_permission_denied.title": {
+      "comment": "Listening mode empty state title for when microphone permissions are required, but the user has denied them",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوصول إلى الميكروفون"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon Adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon Adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofonzugriff"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofonzugriff"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Microphone Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso al micrófono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso al micrófono"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès au microphone"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès au microphone"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "माइक्रोफ़ोन का ऐक्सेस"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "माइक्रोफ़ोन का ऐक्सेस"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso al microfono"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso al microfono"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "마이크 액세스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 액세스"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступ к микрофону"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступ к микрофону"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quyền truy cập vào micrô"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quyền truy cập vào micrô"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "麦克风访问权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麦克风访问权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "麥克風訪問"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風訪問"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_undetermined.action" : {
-      "comment" : "Listening mode empty state action that will allow the user to grant access to microphone permissions via the system permissions alert.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منح صلاحية الوصول"
+    "listening_mode.empty_state.microphone_permission_undetermined.action": {
+      "comment": "Listening mode empty state action that will allow the user to grant access to microphone permissions via the system permissions alert.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منح صلاحية الوصول"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tildel adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tildel adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff gewähren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff gewähren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grant Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dar acceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dar acceso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accorder l’accès"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorder l’accès"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पहुँच प्रदान करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पहुँच प्रदान करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concedi l'accesso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concedi l'accesso"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "액세스 권한 부여"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "액세스 권한 부여"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предоставить доступ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставить доступ"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cấp phép truy cập"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cấp phép truy cập"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予访问权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予访问权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予訪問權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予訪問權限"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_undetermined.message" : {
-      "comment" : "Listening mode empty state message for when microphone permissions are required and the user has not been shown the system permissions prompt yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج Vocable إلى الوصول إلى الميكروفون لتمكين وضع الاستماع. يعرض الزر أدناه مربع حوار إذن iOS الذي لا يمكن لتتبع رأس Vocable التدخل فيه."
+    "listening_mode.empty_state.microphone_permission_undetermined.message": {
+      "comment": "Listening mode empty state message for when microphone permissions are required and the user has not been shown the system permissions prompt yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج Vocable إلى الوصول إلى الميكروفون لتمكين وضع الاستماع. يعرض الزر أدناه مربع حوار إذن iOS الذي لا يمكن لتتبع رأس Vocable التدخل فيه."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable behøver mikrofonadgang for at aktivere Lytningstilstand. Knappen nedenfor viser en iOS-tilladelsesdialog, som Vocable's hovedsporing ikke kan interragere med."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable behøver mikrofonadgang for at aktivere Lytningstilstand. Knappen nedenfor viser en iOS-tilladelsesdialog, som Vocable's hovedsporing ikke kan interragere med."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zum Aktivieren des Hörmodus benötigen Sie Zugriff auf das Mikrofon. Der unten stehende Button zeigt einen Dialog mit iOS-Berechtigungen, mit dem die Head-Tracking von Vocable nicht interrazieren kann."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zum Aktivieren des Hörmodus benötigen Sie Zugriff auf das Mikrofon. Der unten stehende Button zeigt einen Dialog mit iOS-Berechtigungen, mit dem die Head-Tracking von Vocable nicht interrazieren kann."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable needs microphone access to enable Listening Mode. The button below presents an iOS permission dialog that Vocable's head tracking cannot interract with."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necesita acceso al micrófono para habilitar el modo de escucha. El botón a continuación presenta un cuadro de diálogo de permiso de iOS con el que el seguimiento de la cabeza de Vocable no puede interactuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necesita acceso al micrófono para habilitar el modo de escucha. El botón a continuación presenta un cuadro de diálogo de permiso de iOS con el que el seguimiento de la cabeza de Vocable no puede interactuar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable a besoin d'un accès au microphone pour activer le mode d'écoute. Le bouton ci-dessous présente une boîte de dialogue d'autorisation iOS avec laquelle le suivi de la tête de Vocable ne peut pas interagir."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable a besoin d'un accès au microphone pour activer le mode d'écoute. Le bouton ci-dessous présente une boîte de dialogue d'autorisation iOS avec laquelle le suivi de la tête de Vocable ne peut pas interagir."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "लिसनिंग मोड को सक्षम करने के लिए Vocable को माइक्रोफ़ोन एक्सेस की आवश्यकता होती है। नीचे दिया गया बटन एक आईओएस अनुमति संवाद प्रस्तुत करता है जिसमें Vocable की हेड ट्रैकिंग इंटरैक्ट नहीं कर सकती है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लिसनिंग मोड को सक्षम करने के लिए Vocable को माइक्रोफ़ोन एक्सेस की आवश्यकता होती है। नीचे दिया गया बटन एक आईओएस अनुमति संवाद प्रस्तुत करता है जिसमें Vocable की हेड ट्रैकिंग इंटरैक्ट नहीं कर सकती है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable ha bisogno dell'accesso al microfono per abilitare la modalità di ascolto. Il pulsante in basso presenta una finestra di dialogo di autorizzazione iOS con cui il rilevamento della testa di Vocable non può interagire."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable ha bisogno dell'accesso al microfono per abilitare la modalità di ascolto. Il pulsante in basso presenta una finestra di dialogo di autorizzazione iOS con cui il rilevamento della testa di Vocable non può interagire."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable은 듣기 모드를 활성화하기 위해 마이크 액세스가 필요합니다. 아래 버튼은 Vocable의 헤드 트래킹이 상호 작용할 수 없는 iOS 권한 대화 상자를 나타냅니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable은 듣기 모드를 활성화하기 위해 마이크 액세스가 필요합니다. 아래 버튼은 Vocable의 헤드 트래킹이 상호 작용할 수 없는 iOS 권한 대화 상자를 나타냅니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable требуется доступ к микрофону, чтобы включить режим прослушивания. Кнопка ниже представляет диалоговое окно разрешений iOS, с которым не может взаимодействовать отслеживание головы Vocable."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable требуется доступ к микрофону, чтобы включить режим прослушивания. Кнопка ниже представляет диалоговое окно разрешений iOS, с которым не может взаимодействовать отслеживание головы Vocable."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable cần quyền truy cập micrô để bật Chế độ nghe. Nút bên dưới trình bày hộp thoại quyền của iOS mà tính năng theo dõi đầu của Vocable không thể can thiệp vào."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable cần quyền truy cập micrô để bật Chế độ nghe. Nút bên dưới trình bày hộp thoại quyền của iOS mà tính năng theo dõi đầu của Vocable không thể can thiệp vào."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要麦克风访问权限才能启用聆听模式。下面的按钮显示了一个 iOS 权限对话框，Vocable 的头部跟踪无法与之交互。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要麦克风访问权限才能启用聆听模式。下面的按钮显示了一个 iOS 权限对话框，Vocable 的头部跟踪无法与之交互。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要麥克風訪問權限才能啟用聆聽模式。下面的按鈕顯示了一個 iOS 權限對話框，Vocable 的頭部跟踪無法與之交互。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要麥克風訪問權限才能啟用聆聽模式。下面的按鈕顯示了一個 iOS 權限對話框，Vocable 的頭部跟踪無法與之交互。"
           }
         }
       }
     },
-    "listening_mode.empty_state.microphone_permission_undetermined.title" : {
-      "comment" : "Listening mode empty state title for when microphone permissions are required and the user has not been shown the system permissions prompt yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوصول إلى الميكروفون"
+    "listening_mode.empty_state.microphone_permission_undetermined.title": {
+      "comment": "Listening mode empty state title for when microphone permissions are required and the user has not been shown the system permissions prompt yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوصول إلى الميكروفون"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofon Adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofon Adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mikrofonzugriff"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mikrofonzugriff"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Microphone Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Microphone Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso al micrófono"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso al micrófono"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès au microphone"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès au microphone"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "माइक्रोफ़ोन का ऐक्सेस"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "माइक्रोफ़ोन का ऐक्सेस"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso al microfono"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso al microfono"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "마이크 액세스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마이크 액세스"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступ к микрофону"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступ к микрофону"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quyền truy cập vào micrô"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quyền truy cập vào micrô"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "麦克风访问权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麦克风访问权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "麥克風訪問"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風訪問"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_denied.action" : {
-      "comment" : "Listening mode empty state action that will allow the user to open the Settings app in order to grant speech recognition permissions.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح الإعدادات"
+    "listening_mode.empty_state.speech_permission_denied.action": {
+      "comment": "Listening mode empty state action that will allow the user to open the Settings app in order to grant speech recognition permissions.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir configuración"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les paramètres"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स खोलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть настройки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開設置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開設置"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_denied.message" : {
-      "comment" : "Listening mode empty state message for when speech recognition permissions are required, but the user has denied them",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج Vocable إلى التعرف على الكلام لتمكين وضع الاستماع. الرجاء تمكين التعرف على الكلام في إعدادات %1$@.\n\nيمكنك أيضًا تعطيل وضع الاستماع لإخفاء هذه الفئة."
+    "listening_mode.empty_state.speech_permission_denied.message": {
+      "comment": "Listening mode empty state message for when speech recognition permissions are required, but the user has denied them",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج Vocable إلى التعرف على الكلام لتمكين وضع الاستماع. الرجاء تمكين التعرف على الكلام في إعدادات %1$@.\n\nيمكنك أيضًا تعطيل وضع الاستماع لإخفاء هذه الفئة."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable har brug for talegenkendelse for at aktivere Lytningstilstand. Aktiver venligst talegenkendelse i %1$@ Indstillinger.\n\nDu kan også deaktivere Lytningstilstand for at skjule denne kategori."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable har brug for talegenkendelse for at aktivere Lytningstilstand. Aktiver venligst talegenkendelse i %1$@ Indstillinger.\n\nDu kan også deaktivere Lytningstilstand for at skjule denne kategori."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable erfordert eine Spracherkennung, um den Hörmodus zu aktivieren. Bitte aktivieren Sie die Spracherkennung in den %1$@-Einstellungen.\n\nSie können den Hörmodus auch deaktivieren, um diese Kategorie auszublenden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable erfordert eine Spracherkennung, um den Hörmodus zu aktivieren. Bitte aktivieren Sie die Spracherkennung in den %1$@-Einstellungen.\n\nSie können den Hörmodus auch deaktivieren, um diese Kategorie auszublenden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in %1$@ Settings.\n\nYou can also disable Listening Mode to hide this category."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable needs speech recognition to enable Listening Mode. Please enable speech recognition in %1$@ Settings.\n\nYou can also disable Listening Mode to hide this category."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necesita reconocimiento de voz para habilitar el modo de escucha. Habilite el reconocimiento de voz en %1$@ Configuración.\n\nTambién puedes desactivar el modo de escucha para ocultar esta categoría."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necesita reconocimiento de voz para habilitar el modo de escucha. Habilite el reconocimiento de voz en %1$@ Configuración.\n\nTambién puedes desactivar el modo de escucha para ocultar esta categoría."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable a besoin de la reconnaissance vocale pour activer le mode d'écoute. Veuillez activer la reconnaissance vocale dans %1$@ Paramètres.\n\nVous pouvez également désactiver le mode d'écoute pour masquer cette catégorie."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable a besoin de la reconnaissance vocale pour activer le mode d'écoute. Veuillez activer la reconnaissance vocale dans %1$@ Paramètres.\n\nVous pouvez également désactiver le mode d'écoute pour masquer cette catégorie."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "लिसनिंग मोड को सक्षम करने के लिए वोकेबल को वाक् पहचान की आवश्यकता होती है। कृपया %1$@ सेटिंग्स में वाक् पहचान सक्षम करें।\n\nइस श्रेणी को छिपाने के लिए आप श्रवण मोड को भी अक्षम कर सकते हैं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लिसनिंग मोड को सक्षम करने के लिए वोकेबल को वाक् पहचान की आवश्यकता होती है। कृपया %1$@ सेटिंग्स में वाक् पहचान सक्षम करें।\n\nइस श्रेणी को छिपाने के लिए आप श्रवण मोड को भी अक्षम कर सकते हैं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necessita del riconoscimento vocale per abilitare la modalità di ascolto. Abilita il riconoscimento vocale nelle Impostazioni %1$@.\n\nPuoi anche disattivare la modalità di ascolto per nascondere questa categoria."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necessita del riconoscimento vocale per abilitare la modalità di ascolto. Abilita il riconoscimento vocale nelle Impostazioni %1$@.\n\nPuoi anche disattivare la modalità di ascolto per nascondere questa categoria."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable이 듣기 모드를 활성화하려면 음성 인식이 필요합니다. %1$@ 설정에서 음성 인식을 활성화하세요.\n\n청취 모드를 비활성화하여 이 카테고리를 숨길 수도 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable이 듣기 모드를 활성화하려면 음성 인식이 필요합니다. %1$@ 설정에서 음성 인식을 활성화하세요.\n\n청취 모드를 비활성화하여 이 카테고리를 숨길 수도 있습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable требует распознавания речи, чтобы включить режим прослушивания. Пожалуйста, включите распознавание речи в настройках %1$@.\n\nВы также можете отключить режим прослушивания, чтобы скрыть эту категорию."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable требует распознавания речи, чтобы включить режим прослушивания. Пожалуйста, включите распознавание речи в настройках %1$@.\n\nВы также можете отключить режим прослушивания, чтобы скрыть эту категорию."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable cần nhận dạng giọng nói để bật Chế độ nghe. Vui lòng bật nhận dạng giọng nói trong Cài đặt %1$@.\n\nBạn cũng có thể tắt Chế độ nghe để ẩn danh mục này."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable cần nhận dạng giọng nói để bật Chế độ nghe. Vui lòng bật nhận dạng giọng nói trong Cài đặt %1$@.\n\nBạn cũng có thể tắt Chế độ nghe để ẩn danh mục này."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要语音识别才能启用聆听模式。 请在 %1$@ 设置中启用语音识别。\n\n您还可以禁用聆听模式来隐藏此类别。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要语音识别才能启用聆听模式。 请在 %1$@ 设置中启用语音识别。\n\n您还可以禁用聆听模式来隐藏此类别。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要語音辨識才能啟用聆聽模式。 請在 %1$@ 設定中啟用語音辨識。\n\n您也可以停用聆聽模式來隱藏此類別。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要語音辨識才能啟用聆聽模式。 請在 %1$@ 設定中啟用語音辨識。\n\n您也可以停用聆聽模式來隱藏此類別。"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_denied.title" : {
-      "comment" : "Listening mode empty state title for when speech recognition permissions are required, but the user has denied them",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التعرف على الكلام"
+    "listening_mode.empty_state.speech_permission_denied.title": {
+      "comment": "Listening mode empty state title for when speech recognition permissions are required, but the user has denied them",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التعرف على الكلام"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talegenkendelse Software"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talegenkendelse Software"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spracherkennung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech Recognition"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconocimiento de voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconocimiento de voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconnaissance vocale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnaissance vocale"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक् पहचान"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक् पहचान"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riconoscimento vocale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riconoscimento vocale"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 인식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Распознавание речи"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Распознавание речи"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nhận dạng giọng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhận dạng giọng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音识别"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音识别"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音識別"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音識別"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_undetermined.action" : {
-      "comment" : "Listen mode empty state action that will allow the user to grant access to speech recognition permissions via the system permissions alert.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منح صلاحية الوصول"
+    "listening_mode.empty_state.speech_permission_undetermined.action": {
+      "comment": "Listen mode empty state action that will allow the user to grant access to speech recognition permissions via the system permissions alert.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منح صلاحية الوصول"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tildel adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tildel adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff gewähren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff gewähren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grant Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dar acceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dar acceso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accorder l’accès"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorder l’accès"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पहुँच प्रदान करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पहुँच प्रदान करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concedi l'accesso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concedi l'accesso"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "액세스 권한 부여"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "액세스 권한 부여"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предоставить доступ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставить доступ"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cấp phép truy cập"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cấp phép truy cập"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予访问权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予访问权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予訪問權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予訪問權限"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_undetermined.message" : {
-      "comment" : "Listening mode empty state message for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج Vocable إلى طلب أذونات الكلام لتمكين وضع الاستماع. سيقدم هذا مربع حوار إذن iOS لا يمكن أن يتداخل معه تتبع رأس Vocable."
+    "listening_mode.empty_state.speech_permission_undetermined.message": {
+      "comment": "Listening mode empty state message for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج Vocable إلى طلب أذونات الكلام لتمكين وضع الاستماع. سيقدم هذا مربع حوار إذن iOS لا يمكن أن يتداخل معه تتبع رأس Vocable."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable skal anmode om taletilladelser for at aktivere lyttetilstand. Dette vil præsentere en iOS-tilladelsesdialog, som Vocables hovedsporing ikke kan interagere med."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable skal anmode om taletilladelser for at aktivere lyttetilstand. Dette vil præsentere en iOS-tilladelsesdialog, som Vocables hovedsporing ikke kan interagere med."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable muss Sprachberechtigungen anfordern, um den Hörmodus zu aktivieren. Dadurch wird ein iOS-Berechtigungsdialog angezeigt, mit dem die Kopfverfolgung von Vocable nicht interagieren kann."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable muss Sprachberechtigungen anfordern, um den Hörmodus zu aktivieren. Dadurch wird ein iOS-Berechtigungsdialog angezeigt, mit dem die Kopfverfolgung von Vocable nicht interagieren kann."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable needs to request speech permissions to enable Listening Mode. This will present an iOS permission dialog that Vocable's head tracking cannot interract with."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necesita solicitar permisos de voz para habilitar el modo de escucha. Esto presentará un cuadro de diálogo de permiso de iOS con el que el seguimiento de la cabeza de Vocable no puede interactuar."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necesita solicitar permisos de voz para habilitar el modo de escucha. Esto presentará un cuadro de diálogo de permiso de iOS con el que el seguimiento de la cabeza de Vocable no puede interactuar."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable doit demander des autorisations vocales pour activer le mode d'écoute. Cela présentera une boîte de dialogue d'autorisation iOS avec laquelle le suivi de la tête de Vocable ne peut pas interagir."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable doit demander des autorisations vocales pour activer le mode d'écoute. Cela présentera une boîte de dialogue d'autorisation iOS avec laquelle le suivi de la tête de Vocable ne peut pas interagir."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable को लिसनिंग मोड को सक्षम करने के लिए वाक् अनुमतियों का अनुरोध करना होगा। यह एक iOS अनुमति संवाद प्रस्तुत करेगा जिसके साथ Vocable की हेड ट्रैकिंग इंटरैक्ट नहीं कर सकती है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable को लिसनिंग मोड को सक्षम करने के लिए वाक् अनुमतियों का अनुरोध करना होगा। यह एक iOS अनुमति संवाद प्रस्तुत करेगा जिसके साथ Vocable की हेड ट्रैकिंग इंटरैक्ट नहीं कर सकती है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable deve richiedere autorizzazioni vocali per abilitare la modalità di ascolto. Questo presenterà una finestra di dialogo di autorizzazione iOS con cui il rilevamento della testa di Vocable non può interagire."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable deve richiedere autorizzazioni vocali per abilitare la modalità di ascolto. Questo presenterà una finestra di dialogo di autorizzazione iOS con cui il rilevamento della testa di Vocable non può interagire."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable은 듣기 모드를 활성화하기 위해 음성 권한을 요청해야 합니다. 이것은 Vocable의 헤드 트래킹이 상호 작용할 수 없는 iOS 권한 대화 상자를 표시합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable은 듣기 모드를 활성화하기 위해 음성 권한을 요청해야 합니다. 이것은 Vocable의 헤드 트래킹이 상호 작용할 수 없는 iOS 권한 대화 상자를 표시합니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable необходимо запросить разрешения на речь, чтобы включить режим прослушивания. Откроется диалоговое окно разрешений iOS, с которым не может взаимодействовать отслеживание головы Vocable."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable необходимо запросить разрешения на речь, чтобы включить режим прослушивания. Откроется диалоговое окно разрешений iOS, с которым не может взаимодействовать отслеживание головы Vocable."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable cần yêu cầu quyền lời nói để bật Chế độ nghe. Thao tác này sẽ hiển thị hộp thoại quyền của iOS mà tính năng theo dõi đầu của Vocable không thể can thiệp vào."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable cần yêu cầu quyền lời nói để bật Chế độ nghe. Thao tác này sẽ hiển thị hộp thoại quyền của iOS mà tính năng theo dõi đầu của Vocable không thể can thiệp vào."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要请求语音权限才能启用聆听模式。这将显示一个 iOS 权限对话框，Vocable 的头部跟踪无法与之交互。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要请求语音权限才能启用聆听模式。这将显示一个 iOS 权限对话框，Vocable 的头部跟踪无法与之交互。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要請求語音權限才能啟用聆聽模式。這將顯示一個 iOS 權限對話框，Vocable 的頭部跟踪無法與之交互。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要請求語音權限才能啟用聆聽模式。這將顯示一個 iOS 權限對話框，Vocable 的頭部跟踪無法與之交互。"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_permission_undetermined.title" : {
-      "comment" : "Listening mode empty state title for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التعرف على الكلام"
+    "listening_mode.empty_state.speech_permission_undetermined.title": {
+      "comment": "Listening mode empty state title for when speech recognition permissions are required and the user has not been shown the system permissions prompt yet",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التعرف على الكلام"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talegenkendelse Software"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talegenkendelse Software"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spracherkennung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech Recognition"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech Recognition"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconocimiento de voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconocimiento de voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconnaissance vocale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnaissance vocale"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक् पहचान"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक् पहचान"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Riconoscimento vocale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riconoscimento vocale"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 인식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 인식"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Распознавание речи"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Распознавание речи"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nhận dạng giọng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhận dạng giọng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音识别"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音识别"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音識別"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音識別"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_unavailable.message" : {
-      "comment" : "Listening mode error state message for when Apple's speech to text service is unavailable",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تتطلب خدمات الكلام تفعيل إحدى الميزات التالية على جهازك: Siri أو Dictation. يرجى التحقق من إعدادات جهازك وتمكين Siri أو Dictation."
+    "listening_mode.empty_state.speech_unavailable.message": {
+      "comment": "Listening mode error state message for when Apple's speech to text service is unavailable",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتطلب خدمات الكلام تفعيل إحدى الميزات التالية على جهازك: Siri أو Dictation. يرجى التحقق من إعدادات جهازك وتمكين Siri أو Dictation."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taletjenester kræver, at en af følgende funktioner er aktiveret på din enhed: Siri eller Diktering. Tjek venligst dine enhedsindstillinger og aktivér Siri eller Diktering."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taletjenester kræver, at en af følgende funktioner er aktiveret på din enhed: Siri eller Diktering. Tjek venligst dine enhedsindstillinger og aktivér Siri eller Diktering."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Für Sprachdienste muss eine der folgenden Funktionen auf Ihrem Gerät aktiviert sein: Siri oder Diktierfunktion. Bitte überprüfen Sie Ihre Geräteeinstellungen und aktivieren Sie Siri oder Diktierfunktion."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für Sprachdienste muss eine der folgenden Funktionen auf Ihrem Gerät aktiviert sein: Siri oder Diktierfunktion. Bitte überprüfen Sie Ihre Geräteeinstellungen und aktivieren Sie Siri oder Diktierfunktion."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech services require one of the following features to be enabled on your device: Siri or Dictation. Please check your device settings and enable Siri or Dictation."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech services require one of the following features to be enabled on your device: Siri or Dictation. Please check your device settings and enable Siri or Dictation."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los servicios de voz requieren que una de las siguientes funciones esté habilitada en su dispositivo: Siri o Dictado. Verifique la configuración de su dispositivo y habilite Siri o Dictado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los servicios de voz requieren que una de las siguientes funciones esté habilitada en su dispositivo: Siri o Dictado. Verifique la configuración de su dispositivo y habilite Siri o Dictado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les services vocaux nécessitent l'activation de l'une des fonctionnalités suivantes sur votre appareil : Siri ou Dictée. Veuillez vérifier les paramètres de votre appareil et activer Siri ou Dictée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les services vocaux nécessitent l'activation de l'une des fonctionnalités suivantes sur votre appareil : Siri ou Dictée. Veuillez vérifier les paramètres de votre appareil et activer Siri ou Dictée."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक् सेवाओं के लिए आपके डिवाइस पर निम्नलिखित सुविधाओं में से एक को सक्षम करने की आवश्यकता होती है: सिरी या डिक्टेशन। कृपया अपनी डिवाइस सेटिंग जांचें और सिरी या डिक्टेशन सक्षम करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक् सेवाओं के लिए आपके डिवाइस पर निम्नलिखित सुविधाओं में से एक को सक्षम करने की आवश्यकता होती है: सिरी या डिक्टेशन। कृपया अपनी डिवाइस सेटिंग जांचें और सिरी या डिक्टेशन सक्षम करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "I servizi vocali richiedono che una delle seguenti funzioni sia abilitata sul dispositivo: Siri o Dettatura. Controlla le impostazioni del tuo dispositivo e abilita Siri o Dettatura."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I servizi vocali richiedono che una delle seguenti funzioni sia abilitata sul dispositivo: Siri o Dettatura. Controlla le impostazioni del tuo dispositivo e abilita Siri o Dettatura."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 서비스를 사용하려면 장치에서 Siri 또는 받아쓰기 기능 중 하나를 활성화해야 합니다. 장치 설정을 확인하고 Siri 또는 받아쓰기를 활성화하십시오."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 서비스를 사용하려면 장치에서 Siri 또는 받아쓰기 기능 중 하나를 활성화해야 합니다. 장치 설정을 확인하고 Siri 또는 받아쓰기를 활성화하십시오."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Речевые службы требуют, чтобы на вашем устройстве была включена одна из следующих функций: Siri или Диктовка. Пожалуйста, проверьте настройки вашего устройства и включите Siri или Диктовку."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Речевые службы требуют, чтобы на вашем устройстве была включена одна из следующих функций: Siri или Диктовка. Пожалуйста, проверьте настройки вашего устройства и включите Siri или Диктовку."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dịch vụ giọng nói yêu cầu bật một trong các tính năng sau trên thiết bị của bạn: Siri hoặc Đọc chính tả. Vui lòng kiểm tra cài đặt thiết bị của bạn và bật Siri hoặc Đọc chính tả."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dịch vụ giọng nói yêu cầu bật một trong các tính năng sau trên thiết bị của bạn: Siri hoặc Đọc chính tả. Vui lòng kiểm tra cài đặt thiết bị của bạn và bật Siri hoặc Đọc chính tả."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音服务需要在您的设备上启用以下功能之一：Siri 或听写。请检查您的设备设置并启用 Siri 或听写。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音服务需要在您的设备上启用以下功能之一：Siri 或听写。请检查您的设备设置并启用 Siri 或听写。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音服務需要在您的設備上啟用以下功能之一：Siri 或聽寫。請檢查您的設備設置並啟用 Siri 或聽寫。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音服務需要在您的設備上啟用以下功能之一：Siri 或聽寫。請檢查您的設備設置並啟用 Siri 或聽寫。"
           }
         }
       }
     },
-    "listening_mode.empty_state.speech_unavailable.title" : {
-      "comment" : "Listening mode error state title for when Apple's speech to text service is unavailable",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خدمات الكلام غير متوفرة"
+    "listening_mode.empty_state.speech_unavailable.title": {
+      "comment": "Listening mode error state title for when Apple's speech to text service is unavailable",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خدمات الكلام غير متوفرة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taletjenester er ikke tilgængelige"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taletjenester er ikke tilgængelige"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachdienste nicht verfügbar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachdienste nicht verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speech services unavailable"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speech services unavailable"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servicios de voz no disponibles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicios de voz no disponibles"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Services vocaux indisponibles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Services vocaux indisponibles"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "भाषण सेवाएं अनुपलब्ध"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषण सेवाएं अनुपलब्ध"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servizi vocali non disponibili"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servizi vocali non disponibili"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 서비스 이용 불가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 서비스 이용 불가"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голосовые сервисы недоступны"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Голосовые сервисы недоступны"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dịch vụ lời nói không khả dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dịch vụ lời nói không khả dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音服务不可用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音服务不可用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音服務不可用"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音服務不可用"
           }
         }
       }
     },
-    "listening_mode.empty_state.unsupported.message" : {
-      "comment" : "Listening mode empty state message for when microphone permissions are required, but listening mode is unsupported",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذا %1$@ في %2$@ %3$@ لا يدعم وضع الاستماع.\n\nوضع الاستماع متاح حاليا باللغة الإنجليزية فقط ويتطلب تمكين %4$@."
+    "listening_mode.empty_state.unsupported.message": {
+      "comment": "Listening mode empty state message for when microphone permissions are required, but listening mode is unsupported",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذا %1$@ في %2$@ %3$@ لا يدعم وضع الاستماع.\n\nوضع الاستماع متاح حاليا باللغة الإنجليزية فقط ويتطلب تمكين %4$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dette %1$@ på %2$@ %3$@ understøtter ikke Lyttetilstand.\n\nLyttetilstand er i øjeblikket kun tilgængelig på engelsk og kræver %4$@ for at være aktiveret."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dette %1$@ på %2$@ %3$@ understøtter ikke Lyttetilstand.\n\nLyttetilstand er i øjeblikket kun tilgængelig på engelsk og kræver %4$@ for at være aktiveret."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses %1$@ auf %2$@ %3$@ unterstützt den Zuhörmodus nicht.\n\nDer Hörmodus ist derzeit nur auf Englisch verfügbar und erfordert die Aktivierung von %4$@."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses %1$@ auf %2$@ %3$@ unterstützt den Zuhörmodus nicht.\n\nDer Hörmodus ist derzeit nur auf Englisch verfügbar und erfordert die Aktivierung von %4$@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %4$@ to be enabled."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %4$@ to be enabled."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este %1$@ en %2$@ %3$@ no soporta el modo de escucha.\n\nEl modo de escucha solo está disponible actualmente en inglés y requiere que %4$@ esté habilitado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este %1$@ en %2$@ %3$@ no soporta el modo de escucha.\n\nEl modo de escucha solo está disponible actualmente en inglés y requiere que %4$@ esté habilitado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le mode d'écoute.\n\nLe mode d'écoute n'est actuellement disponible qu'en anglais et nécessite l'activation de %4$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le mode d'écoute.\n\nLe mode d'écoute n'est actuellement disponible qu'en anglais et nécessite l'activation de %4$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@ पर यह %1$@ श्रवण मोड का समर्थन नहीं करता है।\n\nलिसनिंग मोड वर्तमान में केवल अंग्रेज़ी में उपलब्ध है और %4$@ को सक्षम करने की आवश्यकता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@ पर यह %1$@ श्रवण मोड का समर्थन नहीं करता है।\n\nलिसनिंग मोड वर्तमान में केवल अंग्रेज़ी में उपलब्ध है और %4$@ को सक्षम करने की आवश्यकता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo %1$@ su %2$@ %3$@ non supporta la modalità di ascolto.\n\nLa modalità di ascolto è attualmente disponibile solo in inglese e richiede %4$@ per essere abilitata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo %1$@ su %2$@ %3$@ non supporta la modalità di ascolto.\n\nLa modalità di ascolto è attualmente disponibile solo in inglese e richiede %4$@ per essere abilitata."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@의 이 %1$@은(는) 듣기 모드를 지원하지 않습니다.\n\n듣기 모드는 현재 영어로만 제공되며 %4$@를 활성화해야 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@의 이 %1$@은(는) 듣기 모드를 지원하지 않습니다.\n\n듣기 모드는 현재 영어로만 제공되며 %4$@를 활성화해야 합니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этот %1$@ на %2$@ %3$@ не поддерживает режим прослушивания.\n\nРежим прослушивания в настоящее время доступен только на английском языке и требует включения %4$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот %1$@ на %2$@ %3$@ не поддерживает режим прослушивания.\n\nРежим прослушивания в настоящее время доступен только на английском языке и требует включения %4$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ trên %2$@ %3$@ này không hỗ trợ Chế độ nghe.\n\nChế độ nghe hiện chỉ khả dụng bằng tiếng Anh và yêu cầu bật %4$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ trên %2$@ %3$@ này không hỗ trợ Chế độ nghe.\n\nChế độ nghe hiện chỉ khả dụng bằng tiếng Anh và yêu cầu bật %4$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此 %1$@ 在 %2$@ %3$@ 不支持侦听模式。\n\n侦听模式目前仅有英文可用，需要启用 %4$@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 %1$@ 在 %2$@ %3$@ 不支持侦听模式。\n\n侦听模式目前仅有英文可用，需要启用 %4$@。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@ 上的這個 %1$@ 不支持聆聽模式。\n\n聆聽模式目前僅提供英文版本，需要啟用 %4$@。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@ 上的這個 %1$@ 不支持聆聽模式。\n\n聆聽模式目前僅提供英文版本，需要啟用 %4$@。"
           }
         }
       }
     },
-    "listening_mode.empty_state.unsupported.title" : {
-      "comment" : "Listening mode empty state title for for when microphone permissions are required, but listening mode is unsupported",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع الاستماع غير مدعوم"
+    "listening_mode.empty_state.unsupported.title": {
+      "comment": "Listening mode empty state title for for when microphone permissions are required, but listening mode is unsupported",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع الاستماع غير مدعوم"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyttetilstand Ikke Understøttet"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyttetilstand Ikke Understøttet"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hörmodus nicht unterstützt"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörmodus nicht unterstützt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening Mode Unsupported"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening Mode Unsupported"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de escucha no soportado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de escucha no soportado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode d'écoute non pris en charge"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode d'écoute non pris en charge"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रवण मोड असमर्थित"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रवण मोड असमर्थित"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità Di Ascolto Non Supportata"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità Di Ascolto Non Supportata"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "듣기 모드 지원되지 않음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "듣기 모드 지원되지 않음"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим прослушивания не поддерживается"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим прослушивания не поддерживается"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ nghe không được hỗ trợ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ nghe không được hỗ trợ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "监听模式不受支持"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监听模式不受支持"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聆聽模式不支持"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聆聽模式不支持"
           }
         }
       }
     },
-    "listening_mode.empty_state.vocableAPIFailure.message" : {
-      "comment" : "Listen mode error state message for when the vocable API fails",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "رجاءً تأكد من اتصالك بالإنترنت وأعد المحاولة لاحقاً."
+    "listening_mode.empty_state.vocableAPIFailure.message": {
+      "comment": "Listen mode error state message for when the vocable API fails",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رجاءً تأكد من اتصالك بالإنترنت وأعد المحاولة لاحقاً."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tjek din internetforbindelse, og prøv igen senere."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tjek din internetforbindelse, og prøv igen senere."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es später erneut."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es später erneut."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please check your internet connection and try again later."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please check your internet connection and try again later."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, comprueba tu conexión de internet e inténtalo más tarde."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, comprueba tu conexión de internet e inténtalo más tarde."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez vérifier votre connexion Internet et réessayer plus tard."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veuillez vérifier votre connexion Internet et réessayer plus tard."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कृपया अपना इंटरनेट कनेक्शन जांचें और बाद में पुनः प्रयास करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कृपया अपना इंटरनेट कनेक्शन जांचें और बाद में पुनः प्रयास करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per favore controlla la tua connessione Internet e riprova più tardi."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per favore controlla la tua connessione Internet e riprova più tardi."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인터넷 연결을 확인하고 나중에 다시 시도해 주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인터넷 연결을 확인하고 나중에 다시 시도해 주세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пожалуйста, проверьте ваше соединение и повторите попытку."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожалуйста, проверьте ваше соединение и повторите попытку."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vui lòng kiểm tra kết nối internet của bạn và thử lại sau."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vui lòng kiểm tra kết nối internet của bạn và thử lại sau."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请检查您的互联网连接并稍后重试。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请检查您的互联网连接并稍后重试。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請檢查您的網路連線並稍後重試。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請檢查您的網路連線並稍後重試。"
           }
         }
       }
     },
-    "listening_mode.empty_state.vocableAPIFailure.title" : {
-      "comment" : "Listen mode error state message for when the vocable API fails",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل الشبكة"
+    "listening_mode.empty_state.vocableAPIFailure.title": {
+      "comment": "Listen mode error state message for when the vocable API fails",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل الشبكة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netværksfejl"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netværksfejl"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkfehler"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkfehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network failure"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network failure"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fallo de red"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fallo de red"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur du réseau"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur du réseau"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नेटवर्क विफलता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नेटवर्क विफलता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errore di rete"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore di rete"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "네트워크 실패"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크 실패"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбой сети"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбой сети"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lỗi mạng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi mạng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网络故障"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络故障"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網路故障"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網路故障"
           }
         }
       }
     },
-    "listening_mode.feedback.confirmation.title" : {
-      "comment" : "Thank you confirmation.  This text appears after sharing with developer",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شكرا لك!"
+    "listening_mode.feedback.confirmation.title": {
+      "comment": "Thank you confirmation.  This text appears after sharing with developer",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شكرا لك!"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tak!"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tak!"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vielen Dank!"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vielen Dank!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thank You!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thank You!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Gracias!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Gracias!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Merci !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merci !"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "धन्यवाद!"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "धन्यवाद!"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grazie!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grazie!"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "감사합니다!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감사합니다!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Спасибо!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Спасибо!"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cảm ơn!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cảm ơn!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "谢谢！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "谢谢！"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "謝謝您！"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "謝謝您！"
           }
         }
       }
     },
-    "listening_mode.feedback.hint.text" : {
-      "comment" : "Information text around what the Share with Deeveloper button does.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا تحب هذه الردود؟ شارك هذا السؤال دون الكشف عن هويتك للمساعدة في تحسين وضع الاستماع."
+    "listening_mode.feedback.hint.text": {
+      "comment": "Information text around what the Share with Deeveloper button does.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا تحب هذه الردود؟ شارك هذا السؤال دون الكشف عن هويتك للمساعدة في تحسين وضع الاستماع."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan du ikke lide disse svar? Anonymt dele dette spørgsmål for at hjælpe med at forbedre lyttetilstand."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan du ikke lide disse svar? Anonymt dele dette spørgsmål for at hjælpe med at forbedre lyttetilstand."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gefallen Ihnen diese Antworten nicht? Teilen Sie diese Frage anonym, um den Hörmodus zu verbessern."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gefallen Ihnen diese Antworten nicht? Teilen Sie diese Frage anonym, um den Hörmodus zu verbessern."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Don’t like these responses? Anonymously share this question to help improve listening mode."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Don’t like these responses? Anonymously share this question to help improve listening mode."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿No te gustan estas respuestas? Comparta anónimamente esta pregunta para ayudar a mejorar el modo de escucha."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿No te gustan estas respuestas? Comparta anónimamente esta pregunta para ayudar a mejorar el modo de escucha."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous n'aimez pas ces réponses ? Partagez anonymement cette question pour aider à améliorer le mode d'écoute."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous n'aimez pas ces réponses ? Partagez anonymement cette question pour aider à améliorer le mode d'écoute."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ये प्रतिक्रियाएं पसंद नहीं हैं? सुनने के तरीके को बेहतर बनाने में सहायता के लिए इस प्रश्न को गुमनाम रूप से साझा करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ये प्रतिक्रियाएं पसंद नहीं हैं? सुनने के तरीके को बेहतर बनाने में सहायता के लिए इस प्रश्न को गुमनाम रूप से साझा करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non ti piacciono queste risposte? Anonimamente condividere questa domanda per aiutare a migliorare la modalità di ascolto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non ti piacciono queste risposte? Anonimamente condividere questa domanda per aiutare a migliorare la modalità di ascolto."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이러한 반응이 마음에 들지 않습니까? 듣기 모드를 개선하는 데 도움이 되도록 이 질문을 익명으로 공유하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이러한 반응이 마음에 들지 않습니까? 듣기 모드를 개선하는 데 도움이 되도록 이 질문을 익명으로 공유하세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не нравятся эти ответы? Анонимно поделитесь этим вопросом, чтобы улучшить режим прослушивания."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не нравятся эти ответы? Анонимно поделитесь этим вопросом, чтобы улучшить режим прослушивания."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn không thích những câu trả lời này? Chia sẻ ẩn danh câu hỏi này để giúp cải thiện chế độ nghe."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn không thích những câu trả lời này? Chia sẻ ẩn danh câu hỏi này để giúp cải thiện chế độ nghe."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不喜欢这些响应？匿名分享这个问题以帮助改善监听模式。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不喜欢这些响应？匿名分享这个问题以帮助改善监听模式。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不喜歡這些回复？匿名分享此問題以幫助改善聆聽模式。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不喜歡這些回复？匿名分享此問題以幫助改善聆聽模式。"
           }
         }
       }
     },
-    "listening_mode.feedback.submit.title" : {
-      "comment" : "Share with Developer button.  The button appears if Listen mode could not generate a reponese.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "شارك مع المطورين"
+    "listening_mode.feedback.submit.title": {
+      "comment": "Share with Developer button.  The button appears if Listen mode could not generate a reponese.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شارك مع المطورين"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Del med udviklere"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Del med udviklere"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit Entwicklern teilen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mit Entwicklern teilen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share with Developers"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share with Developers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir con desarrolladores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir con desarrolladores"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partager avec les développeurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partager avec les développeurs"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डेवलपर्स के साथ साझा करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डेवलपर्स के साथ साझा करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Condividi con gli sviluppatori"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Condividi con gli sviluppatori"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개발자와 공유"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개발자와 공유"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поделиться с разработчиками"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поделиться с разработчиками"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chia sẻ với các nhà phát triển"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chia sẻ với các nhà phát triển"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与开发者分享"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与开发者分享"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "與開發者分享"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與開發者分享"
           }
         }
       }
     },
-    "main_screen.textfield_placeholder.default" : {
-      "comment" : "Select something below to speak Hint Text",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حدد شيئا أدناه للتحدث"
+    "main_screen.textfield_placeholder.default": {
+      "comment": "Select something below to speak Hint Text",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حدد شيئا أدناه للتحدث"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vælg noget nedenunder for at snakke"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vælg noget nedenunder for at snakke"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wähle unten etwas aus, um zu sprechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle unten etwas aus, um zu sprechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select something below to speak"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select something below to speak"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona algo a continuación para hablar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciona algo a continuación para hablar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez quelque chose ci-dessous pour parler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez quelque chose ci-dessous pour parler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "बोलने के लिए नीचे कुछ चुनें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बोलने के लिए नीचे कुछ चुनें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona qualcosa qui sotto per parlare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona qualcosa qui sotto per parlare"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아래에서 말할 항목을 선택하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아래에서 말할 항목을 선택하세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите что-нибудь ниже, чтобы говорить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите что-нибудь ниже, чтобы говорить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn một cái gì đó bên dưới để nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn một cái gì đó bên dưới để nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请选择下面要说的对话"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择下面要说的对话"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇以下內容進行發言"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇以下內容進行發言"
           }
         }
       }
     },
-    "paging_progress_indicator_format" : {
-      "comment" : "Page indicator progress format. \\\"Page x of n\\\"",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "صفحه %1$d من %2$d"
+    "paging_progress_indicator_format": {
+      "comment": "Page indicator progress format. \\\"Page x of n\\\"",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحه %1$d من %2$d"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Side %1$d af %2$d"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Side %1$d af %2$d"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seite %1$d von %2$d"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seite %1$d von %2$d"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page %1$d of %2$d"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page %1$d of %2$d"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Página %1$d de %2$d"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página %1$d de %2$d"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page %1$d sur %2$d"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page %1$d sur %2$d"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पेज क्रमांक %1$d कुल %2$d पेजों में से"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पेज क्रमांक %1$d कुल %2$d पेजों में से"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagina %1$d di %2$d"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagina %1$d di %2$d"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$d 중 %1$d 페이지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$d 중 %1$d 페이지"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Страница %1$d из %2$d"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Страница %1$d из %2$d"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trang %1$d / %2$d"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trang %1$d / %2$d"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "第 %1$d/%2$d 頁"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$d/%2$d 頁"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "第 %1$d 頁，共 %2$d 頁"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$d 頁，共 %2$d 頁"
           }
         }
       }
     },
-    "personal_voices.empty_state.denied.button.title" : {
-      "comment" : "Action button for the personal voices screen allowing the user to open the system settings app to resolve an error.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فتح الإعدادات"
+    "personal_voices.empty_state.denied.button.title": {
+      "comment": "Action button for the personal voices screen allowing the user to open the system settings app to resolve an error.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Åbn Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen öffnen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir configuración"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir les paramètres"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स खोलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 열기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть настройки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開設置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開設置"
           }
         }
       }
     },
-    "personal_voices.empty_state.denied.description" : {
-      "comment" : "Empty state description for when Personal Voice access has been denied by the user. It informs the user how to re-enable access by navigating to system settings. The placeholder is the device model (e.g. \"iPhone\" or \"iPad\")",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يحتاج Vocable إلى إذن للوصول إلى الأصوات الشخصية على هذا الجهاز.\n\nيمكنك تمكين الوصول في إعدادات %1$@.\n\nتتوفر ميزة الصوت الشخصي فقط على نظام التشغيل iOS 17 أو أحدث وعلى iPhone 12 أو أحدث، أو iPad (M1 أو أحدث)"
+    "personal_voices.empty_state.denied.description": {
+      "comment": "Empty state description for when Personal Voice access has been denied by the user. It informs the user how to re-enable access by navigating to system settings. The placeholder is the device model (e.g. \"iPhone\" or \"iPad\")",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتاج Vocable إلى إذن للوصول إلى الأصوات الشخصية على هذا الجهاز.\n\nيمكنك تمكين الوصول في إعدادات %1$@.\n\nتتوفر ميزة الصوت الشخصي فقط على نظام التشغيل iOS 17 أو أحدث وعلى iPhone 12 أو أحدث، أو iPad (M1 أو أحدث)"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable har brug for tilladelse til at tilgå personlige stemmer på denne enhed.\n\nDu kan aktivere adgang i %1$@ Indstillinger. \n\nPersonal Stemmer er kun tilgængelig på iOS 17+ på iPhone 12+ eller iPad (M1 eller senere)"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable har brug for tilladelse til at tilgå personlige stemmer på denne enhed.\n\nDu kan aktivere adgang i %1$@ Indstillinger. \n\nPersonal Stemmer er kun tilgængelig på iOS 17+ på iPhone 12+ eller iPad (M1 eller senere)"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable benötigt die Berechtigung, um auf persönliche stimme auf diesem Gerät zuzugreifen.\n\nSie können den Zugriff in %1$@ Einstellungen aktivieren. \n\nPersönliche Stimme ist nur auf iOS 17+ auf dem iPhone 12+ oder iPad (M1 oder neuer) verfügbar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable benötigt die Berechtigung, um auf persönliche stimme auf diesem Gerät zuzugreifen.\n\nSie können den Zugriff in %1$@ Einstellungen aktivieren. \n\nPersönliche Stimme ist nur auf iOS 17+ auf dem iPhone 12+ oder iPad (M1 oder neuer) verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings. \n\nPersonal Voice is only available on iOS 17+ on iPhone 12+ or iPad (M1 or later)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable needs permission to access Personal Voices on this device.\n\nYou can enable access in %1$@ Settings. \n\nPersonal Voice is only available on iOS 17+ on iPhone 12+ or iPad (M1 or later)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable necesita permiso para acceder a Votos Personales en este dispositivo.\n\nPuede habilitar el acceso en Ajustes %1$@. \n\nVoz personal solamente está disponible en iOS 17+ en iPhone 12+ o iPad (M1 o superior)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable necesita permiso para acceder a Votos Personales en este dispositivo.\n\nPuede habilitar el acceso en Ajustes %1$@. \n\nVoz personal solamente está disponible en iOS 17+ en iPhone 12+ o iPad (M1 o superior)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La fonction vocable nécessite l'autorisation d'accéder aux Voix personnelles sur cet appareil.\n\nVous pouvez activer l'accès dans les paramètres %1$@. \n\nLa Voix Personnelle n'est disponible que sur iOS 17+ sur iPhone 12+ ou iPad (M1 ou supérieur)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fonction vocable nécessite l'autorisation d'accéder aux Voix personnelles sur cet appareil.\n\nVous pouvez activer l'accès dans les paramètres %1$@. \n\nLa Voix Personnelle n'est disponible que sur iOS 17+ sur iPhone 12+ ou iPad (M1 ou supérieur)"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वोकेबल को इस डिवाइस पर व्यक्तिगत आवाज़ों तक पहुंचने के लिए अनुमति की आवश्यकता है।\n\nआप %1$@ सेटिंग्स में पहुंच सक्षम कर सकते हैं।\n\nपर्सनल वॉइस सिर्फ़ iOS 17+ पर iPhone 12+ या iPad (M1 या बाद के वर्शन) पर उपलब्ध है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वोकेबल को इस डिवाइस पर व्यक्तिगत आवाज़ों तक पहुंचने के लिए अनुमति की आवश्यकता है।\n\nआप %1$@ सेटिंग्स में पहुंच सक्षम कर सकते हैं।\n\nपर्सनल वॉइस सिर्फ़ iOS 17+ पर iPhone 12+ या iPad (M1 या बाद के वर्शन) पर उपलब्ध है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable ha bisogno di permessi per accedere alle Voci Personali su questo dispositivo.\n\nPuoi abilitare l'accesso nelle Impostazioni di %1$@. \n\nVoce personale è disponibile solo su iOS 17+ su iPhone 12+ o iPad (M1 o successivo)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable ha bisogno di permessi per accedere alle Voci Personali su questo dispositivo.\n\nPuoi abilitare l'accesso nelle Impostazioni di %1$@. \n\nVoce personale è disponibile solo su iOS 17+ su iPhone 12+ o iPad (M1 o successivo)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable이 이 기기에서 개인 음성에 액세스하려면 권한이 필요합니다.\n\n%1$@ 설정에서 액세스를 활성화할 수 있습니다.\n\n개인 음성 기능은 iOS 17 이상이 설치된 iPhone 12 이상 또는 iPad(M1 이상)에서만 사용할 수 있습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable이 이 기기에서 개인 음성에 액세스하려면 권한이 필요합니다.\n\n%1$@ 설정에서 액세스를 활성화할 수 있습니다.\n\n개인 음성 기능은 iOS 17 이상이 설치된 iPhone 12 이상 또는 iPad(M1 이상)에서만 사용할 수 있습니다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable требуется разрешение на доступ к Personal Voices на этом устройстве.\n\nВы можете включить доступ в настройках %1$@.\n\nФункция «Персональный голос» доступна только на устройствах с iOS 17 и выше, таких как iPhone 12 и iPad (M1 или более поздние модели)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable требуется разрешение на доступ к Personal Voices на этом устройстве.\n\nВы можете включить доступ в настройках %1$@.\n\nФункция «Персональный голос» доступна только на устройствах с iOS 17 и выше, таких как iPhone 12 и iPad (M1 или более поздние модели)"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable cần có quyền truy cập Giọng nói cá nhân trên thiết bị này.\n\nBạn có thể kích hoạt quyền truy cập trong Cài đặt %1$@.\n\nTính năng Giọng nói cá nhân chỉ khả dụng trên iOS 17 trở lên trên iPhone 12 trở lên hoặc iPad (M1 trở lên)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable cần có quyền truy cập Giọng nói cá nhân trên thiết bị này.\n\nBạn có thể kích hoạt quyền truy cập trong Cài đặt %1$@.\n\nTính năng Giọng nói cá nhân chỉ khả dụng trên iOS 17 trở lên trên iPhone 12 trở lên hoặc iPad (M1 trở lên)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要获得访问此设备上的个人语音的权限。\n\n您可以在%1$@ 设置中启用访问。\n\n个人语音功能仅适用于运行 iOS 17 及更高版本的 iPhone 12 及更高版本或 iPad（M1 或更新机型）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要获得访问此设备上的个人语音的权限。\n\n您可以在%1$@ 设置中启用访问。\n\n个人语音功能仅适用于运行 iOS 17 及更高版本的 iPhone 12 及更高版本或 iPad（M1 或更新机型）"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 需要獲得存取此裝置上的個人語音的權限。\n\n您可以在%1$@ 設定中啟用存取。\n\n個人語音功能僅適用於運行 iOS 17 及更高版本的 iPhone 12 及更高版本或 iPad（M1 或更新機型）"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 需要獲得存取此裝置上的個人語音的權限。\n\n您可以在%1$@ 設定中啟用存取。\n\n個人語音功能僅適用於運行 iOS 17 及更高版本的 iPhone 12 及更高版本或 iPad（M1 或更新機型）"
           }
         }
       }
     },
-    "personal_voices.empty_state.denied.title" : {
-      "comment" : "Title of the Personal Voices screen empty state when a user must grant access to the app.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوصول الصوتي الشخصي"
+    "personal_voices.empty_state.denied.title": {
+      "comment": "Title of the Personal Voices screen empty state when a user must grant access to the app.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوصول الصوتي الشخصي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personlig Stemme Adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personlig Stemme Adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persönlicher Sprachzugriff"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persönlicher Sprachzugriff"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal Voice Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal Voice Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso a Voz Personal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso a Voz Personal"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès vocal personnel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès vocal personnel"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "व्यक्तिगत वॉयस एक्सेस"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "व्यक्तिगत वॉयस एक्सेस"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso Vocale Personale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso Vocale Personale"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 음성 액세스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 음성 액세스"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Личный доступ к голосу"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Личный доступ к голосу"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Truy cập bằng giọng nói cá nhân"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Truy cập bằng giọng nói cá nhân"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "个人语音访问"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个人语音访问"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人語音訪問"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人語音訪問"
           }
         }
       }
     },
-    "personal_voices.empty_state.no_content.description" : {
-      "comment" : "Empty state description for when there are not personal voices to display. This is typically because the user has not created any yet. The placeholder is the device model (e.g. \"iPhone\" or \"iPad\").",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يمكنك إنشاء صوت شخصي جديد في إعدادات %1$@. بمجرد إنشائه، يمكنك تعيين صوتك الشخصي كصوت للمفرد.\n\nإذا تم إنشاء صوت شخصي ولا يظهر في Vocable ، حاول إعادة تشغيل %1$@."
+    "personal_voices.empty_state.no_content.description": {
+      "comment": "Empty state description for when there are not personal voices to display. This is typically because the user has not created any yet. The placeholder is the device model (e.g. \"iPhone\" or \"iPad\").",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يمكنك إنشاء صوت شخصي جديد في إعدادات %1$@. بمجرد إنشائه، يمكنك تعيين صوتك الشخصي كصوت للمفرد.\n\nإذا تم إنشاء صوت شخصي ولا يظهر في Vocable ، حاول إعادة تشغيل %1$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du kan oprette en ny personlig stemme i %1$@ indstillinger. Når den er oprettet, kan du indstille din personlige stemme som Vocable's stemme.\n\nHvis en personlig stemme er blevet oprettet og ikke vises i Vocable, så prøv at genstarte %1$@."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du kan oprette en ny personlig stemme i %1$@ indstillinger. Når den er oprettet, kan du indstille din personlige stemme som Vocable's stemme.\n\nHvis en personlig stemme er blevet oprettet og ikke vises i Vocable, så prøv at genstarte %1$@."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie können in den %1$@ Einstellungen eine neue Persönliche Stimme erstellen. Einmal erstellt, können Sie Ihre Persönliche Stimme als Voicable festlegen.\n\nWenn eine persönliche Stimme erstellt wurde und nicht in Vocable erscheint, versuchen Sie %1$@ neu zu starten."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie können in den %1$@ Einstellungen eine neue Persönliche Stimme erstellen. Einmal erstellt, können Sie Ihre Persönliche Stimme als Voicable festlegen.\n\nWenn eine persönliche Stimme erstellt wurde und nicht in Vocable erscheint, versuchen Sie %1$@ neu zu starten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can create a new Personal Voice in %1$@ Settings. Once created, you can set your Personal Voice as Vocable's voice.\n\nIf a Personal Voice has been created and does not appear in Vocable, try restarting %1$@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can create a new Personal Voice in %1$@ Settings. Once created, you can set your Personal Voice as Vocable's voice.\n\nIf a Personal Voice has been created and does not appear in Vocable, try restarting %1$@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puedes crear una nueva voz personal en %1$@ Configuración. Una vez creada, puede configurar su Voz personal como la voz de Vocable.\n\nSi se creó una voz personal y no aparece en Vocable, intente reiniciar %1$@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puedes crear una nueva voz personal en %1$@ Configuración. Una vez creada, puede configurar su Voz personal como la voz de Vocable.\n\nSi se creó una voz personal y no aparece en Vocable, intente reiniciar %1$@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous pouvez créer une nouvelle voix personnelle dans %1$@ Paramètres. Une fois créé, vous pouvez définir votre voix personnelle comme voix de Vocable.\n\nSi une voix personnelle a été créée et n'apparaît pas dans Vocable, essayez de redémarrer %1$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous pouvez créer une nouvelle voix personnelle dans %1$@ Paramètres. Une fois créé, vous pouvez définir votre voix personnelle comme voix de Vocable.\n\nSi une voix personnelle a été créée et n'apparaît pas dans Vocable, essayez de redémarrer %1$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आप %1$@ सेटिंग्स में एक नई व्यक्तिगत आवाज़ बना सकते हैं। एक बार बन जाने के बाद, आप अपनी व्यक्तिगत आवाज़ को वोकेबल की आवाज़ के रूप में सेट कर सकते हैं।\n\nयदि कोई व्यक्तिगत आवाज़ बनाई गई है और वोकेबल में दिखाई नहीं देती है, तो %1$@ को पुनः आरंभ करने का प्रयास करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आप %1$@ सेटिंग्स में एक नई व्यक्तिगत आवाज़ बना सकते हैं। एक बार बन जाने के बाद, आप अपनी व्यक्तिगत आवाज़ को वोकेबल की आवाज़ के रूप में सेट कर सकते हैं।\n\nयदि कोई व्यक्तिगत आवाज़ बनाई गई है और वोकेबल में दिखाई नहीं देती है, तो %1$@ को पुनः आरंभ करने का प्रयास करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puoi creare una nuova Voce Personale nelle Impostazioni di %1$@. Una volta creata, puoi impostare la tua Voce Personale come Vocabile.\n\nSe una Voce Personale è stata creata e non appare in Vocabile, prova a riavviare %1$@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puoi creare una nuova Voce Personale nelle Impostazioni di %1$@. Una volta creata, puoi impostare la tua Voce Personale come Vocabile.\n\nSe una Voce Personale è stata creata e non appare in Vocabile, prova a riavviare %1$@."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 설정에서 새 개인 음성을 만들 수 있습니다. 생성된 후에는 개인 음성을 Vocable의 음성으로 설정할 수 있습니다.\n\n개인 음성이 생성되었지만 Vocable에 표시되지 않는 경우 %1$@을(를) 다시 시작해 보세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 설정에서 새 개인 음성을 만들 수 있습니다. 생성된 후에는 개인 음성을 Vocable의 음성으로 설정할 수 있습니다.\n\n개인 음성이 생성되었지만 Vocable에 표시되지 않는 경우 %1$@을(를) 다시 시작해 보세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы можете создать новый личный голос в настройках %1$@. После создания вы можете задать свой голос как голос для вокала.\n\nЕсли персональный голос был создан и не отображается в разделе \"Словарь\", попробуйте перезапустить %1$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы можете создать новый личный голос в настройках %1$@. После создания вы можете задать свой голос как голос для вокала.\n\nЕсли персональный голос был создан и не отображается в разделе \"Словарь\", попробуйте перезапустить %1$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có thể tạo Giọng nói cá nhân mới trong Cài đặt %1$@. Sau khi tạo, bạn có thể đặt Giọng nói cá nhân của mình làm giọng nói của Vocable.\n\nNếu Giọng nói Cá nhân đã được tạo và không xuất hiện trong Từ vựng, hãy thử khởi động lại %1$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có thể tạo Giọng nói cá nhân mới trong Cài đặt %1$@. Sau khi tạo, bạn có thể đặt Giọng nói cá nhân của mình làm giọng nói của Vocable.\n\nNếu Giọng nói Cá nhân đã được tạo và không xuất hiện trong Từ vựng, hãy thử khởi động lại %1$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您可以在 %1$@ 设置中创建一个新的个人语音。一旦创建，您可以将您的个人语音设置为词汇。\n\n如果个人语音已被创建并且没有出现在词汇中，请尝试重启 %1$@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您可以在 %1$@ 设置中创建一个新的个人语音。一旦创建，您可以将您的个人语音设置为词汇。\n\n如果个人语音已被创建并且没有出现在词汇中，请尝试重启 %1$@。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您可以在%1$@ 設定中建立新的個人語音。 建立後，您可以將您的個人語音設定為 Vocable 的語音。\n\n如果個人語音已建立但未出現在 Vocable 中，請嘗試重新啟動 %1$@。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您可以在%1$@ 設定中建立新的個人語音。 建立後，您可以將您的個人語音設定為 Vocable 的語音。\n\n如果個人語音已建立但未出現在 Vocable 中，請嘗試重新啟動 %1$@。"
           }
         }
       }
     },
-    "personal_voices.empty_state.no_content.title" : {
-      "comment" : "Title of the Personal Voices screen empty state when there are no voices available on the device.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا أصوات شخصية"
+    "personal_voices.empty_state.no_content.title": {
+      "comment": "Title of the Personal Voices screen empty state when there are no voices available on the device.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا أصوات شخصية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen Personlige Stemmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen Personlige Stemmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Persönliche Stimme"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Persönliche Stimme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Personal Voices"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Personal Voices"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin Voces Personales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin Voces Personales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas de voix personnelles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas de voix personnelles"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कोई व्यक्तिगत आवाज नहीं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई व्यक्तिगत आवाज नहीं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna Voce Personale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna Voce Personale"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 음성 없음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 음성 없음"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Никаких личных голосов"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Никаких личных голосов"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có tiếng nói cá nhân"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có tiếng nói cá nhân"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有个人声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有个人声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有個人聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有個人聲音"
           }
         }
       }
     },
-    "personal_voices.empty_state.not_authorized.button.title" : {
-      "comment" : "Action button for the personal voices screen that will display a system prompt allowing access to their Personal Voice profiles stored on their device.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "منح صلاحية الوصول"
+    "personal_voices.empty_state.not_authorized.button.title": {
+      "comment": "Action button for the personal voices screen that will display a system prompt allowing access to their Personal Voice profiles stored on their device.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منح صلاحية الوصول"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tildel adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tildel adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff gewähren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriff gewähren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grant Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grant Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dar acceso"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dar acceso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accorder l’accès"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accorder l’accès"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पहुँच प्रदान करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पहुँच प्रदान करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concedi l'accesso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concedi l'accesso"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "액세스 권한 부여"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "액세스 권한 부여"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предоставить доступ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предоставить доступ"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cấp phép truy cập"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cấp phép truy cập"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予访问权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予访问权限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "授予訪問權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予訪問權限"
           }
         }
       }
     },
-    "personal_voices.empty_state.not_authorized.description" : {
-      "comment" : "Empty state description for when Personal Voice access has not yet been prompted to the user. Below this text will be a button that will prompt the user for access.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسمح لـ Vocable بالوصول إلى الأصوات الشخصية المخزنة على هذا الجهاز."
+    "personal_voices.empty_state.not_authorized.description": {
+      "comment": "Empty state description for when Personal Voice access has not yet been prompted to the user. Below this text will be a button that will prompt the user for access.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسمح لـ Vocable بالوصول إلى الأصوات الشخصية المخزنة على هذا الجهاز."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tillad Vocable at få adgang til personlige stemmer gemt på denne enhed."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillad Vocable at få adgang til personlige stemmer gemt på denne enhed."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erlaube Zugriff auf die auf diesem Gerät gespeicherten Persönlichen Stimmen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaube Zugriff auf die auf diesem Gerät gespeicherten Persönlichen Stimmen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allow Vocable to access Personal Voices stored on this device."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow Vocable to access Personal Voices stored on this device."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permitir el acceso a Voces Personales almacenados en este dispositivo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir el acceso a Voces Personales almacenados en este dispositivo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser l'accès aux Voix Personnelles stockées sur cet appareil."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser l'accès aux Voix Personnelles stockées sur cet appareil."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वोकेबल को इस डिवाइस पर संग्रहीत व्यक्तिगत आवाज़ों तक पहुंचने की अनुमति दें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वोकेबल को इस डिवाइस पर संग्रहीत व्यक्तिगत आवाज़ों तक पहुंचने की अनुमति दें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Consenti a Vocabile di accedere alle Voci Personali memorizzate su questo dispositivo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti a Vocabile di accedere alle Voci Personali memorizzate su questo dispositivo."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable이 이 기기에 저장된 개인 음성에 액세스하도록 허용하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable이 이 기기에 저장된 개인 음성에 액세스하도록 허용하세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разрешить доступ к личным голосам, хранящимся на этом устройстве."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить доступ к личным голосам, хранящимся на этом устройстве."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cho phép Vocable truy cập Giọng nói cá nhân được lưu trữ trên thiết bị này."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cho phép Vocable truy cập Giọng nói cá nhân được lưu trữ trên thiết bị này."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允许 Vocable 访问此设备上存储的个人语音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许 Vocable 访问此设备上存储的个人语音。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "允許 Vocable 存取此裝置上儲存的個人語音。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許 Vocable 存取此裝置上儲存的個人語音。"
           }
         }
       }
     },
-    "personal_voices.empty_state.not_authorized.title" : {
-      "comment" : "Title of the Personal Voices screen empty state when a user has denied access to the app.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوصول الصوتي الشخصي"
+    "personal_voices.empty_state.not_authorized.title": {
+      "comment": "Title of the Personal Voices screen empty state when a user has denied access to the app.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوصول الصوتي الشخصي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personlig Stemme Adgang"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personlig Stemme Adgang"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persönlicher Sprachzugriff"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persönlicher Sprachzugriff"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal Voice Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal Voice Access"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso a Voz Personal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso a Voz Personal"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès vocal personnel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès vocal personnel"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "व्यक्तिगत वॉयस एक्सेस"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "व्यक्तिगत वॉयस एक्सेस"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso Vocale Personale"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso Vocale Personale"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 음성 액세스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 음성 액세스"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Личный доступ к голосу"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Личный доступ к голосу"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Truy cập bằng giọng nói cá nhân"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Truy cập bằng giọng nói cá nhân"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "个人语音访问"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个人语音访问"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人語音訪問"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人語音訪問"
           }
         }
       }
     },
-    "personal_voices.title" : {
-      "comment" : "Title of the Personal Voices screen",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الأصوات الشخصية"
+    "personal_voices.title": {
+      "comment": "Title of the Personal Voices screen",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأصوات الشخصية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personlige Stemmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personlige Stemmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persönliche Stimmen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persönliche Stimmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal Voices"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal Voices"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voces Personales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voces Personales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix personnelles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix personnelles"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "व्यक्तिगत आवाज़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "व्यक्तिगत आवाज़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voci personali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voci personali"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 음성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 음성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Личные голоса"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Личные голоса"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếng nói cá nhân"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng nói cá nhân"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "个人语音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个人语音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人聲音"
           }
         }
       }
     },
-    "phrase_editor.alert.cancel_editing_confirmation.button.continue_editing.title" : {
-      "comment" : "Button in the Phrase close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will allow editing the category title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الاستمرار في التعديل"
+    "phrase_editor.alert.cancel_editing_confirmation.button.continue_editing.title": {
+      "comment": "Button in the Phrase close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will allow editing the category title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستمرار في التعديل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortsæt Redigering"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsæt Redigering"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter editieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter editieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue Editing"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue Editing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar Edición"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar Edición"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer l'édition"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer l'édition"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "संपादन जारी रखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संपादन जारी रखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua la modifica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua la modifica"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계속 편집"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속 편집"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить редактирование"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить редактирование"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếp tục chỉnh sửa"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục chỉnh sửa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续编辑"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续编辑"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繼續編輯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續編輯"
           }
         }
       }
     },
-    "phrase_editor.alert.cancel_editing_confirmation.button.discard.title" : {
-      "comment" : "Button in the edit Phrase close confirmation.  This button appears in an alert when there are edits made to the Phrase and the user tries to close the keyboard without saving the changes. Pressing the button will not save any changes and close the keyboard view.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاهل"
+    "phrase_editor.alert.cancel_editing_confirmation.button.discard.title": {
+      "comment": "Button in the edit Phrase close confirmation.  This button appears in an alert when there are edits made to the Phrase and the user tries to close the keyboard without saving the changes. Pressing the button will not save any changes and close the keyboard view.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تجاهل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slet"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slet"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwerfen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwerfen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discard"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeter"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "छोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "छोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scartare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scartare"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버리다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버리다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отказаться"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отказаться"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ đi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ đi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "舍弃"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "舍弃"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "丟棄"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "丟棄"
           }
         }
       }
     },
-    "phrase_editor.alert.cancel_editing_confirmation.title" : {
-      "comment" : "Phrase editor close confirmation text.  This text appears in an alert when there are edits made to the Phrase and the user tries to close the keyboard without saving the changes.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إذا أغلقت بدون حفظ ، فستفقد التغييرات."
+    "phrase_editor.alert.cancel_editing_confirmation.title": {
+      "comment": "Phrase editor close confirmation text.  This text appears in an alert when there are edits made to the Phrase and the user tries to close the keyboard without saving the changes.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إذا أغلقت بدون حفظ ، فستفقد التغييرات."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hvis du lukker uden at gemme, vil dine ændringer gå tabt."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hvis du lukker uden at gemme, vil dine ændringer gå tabt."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie ohne Speichern schließen, gehen Ihre Änderungen verloren."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie ohne Speichern schließen, gehen Ihre Änderungen verloren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you close without saving, your changes will be lost."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you close without saving, your changes will be lost."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si cierra sin guardar, sus cambios se perderán."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si cierra sin guardar, sus cambios se perderán."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si vous fermez sans enregistrer, vos modifications seront perdues."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si vous fermez sans enregistrer, vos modifications seront perdues."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यदि आप सहेजे बिना बंद कर देते हैं, तो आपके परिवर्तन खो जाएंगे।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यदि आप सहेजे बिना बंद कर देते हैं, तो आपके परिवर्तन खो जाएंगे।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se si chiude senza salvare, le modifiche andranno perse."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se si chiude senza salvare, le modifiche andranno perse."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "저장하지 않고 닫으면 변경 사항이 손실됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장하지 않고 닫으면 변경 사항이 손실됩니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Если вы закроете без сохранения, ваши изменения будут потеряны."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если вы закроете без сохранения, ваши изменения будут потеряны."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nếu bạn đóng mà không lưu, các thay đổi của bạn sẽ bị mất."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nếu bạn đóng mà không lưu, các thay đổi của bạn sẽ bị mất."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您关闭而不保存，您的更改将丢失。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您关闭而不保存，您的更改将丢失。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您關閉而不保存，您的更改將會丟失。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您關閉而不保存，您的更改將會丟失。"
           }
         }
       }
     },
-    "phrase_editor.alert.phrase_name_exists.cancel.button" : {
-      "comment" : "Duplicate Phrase alert cancel button. Text on this button appears on an alert where a duplicate phrase is being created. Pressing the button allows the user to continue editing the category title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "phrase_editor.alert.phrase_name_exists.cancel.button": {
+      "comment": "Duplicate Phrase alert cancel button. Text on this button appears on an alert where a duplicate phrase is being created. Pressing the button allows the user to continue editing the category title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "phrase_editor.alert.phrase_name_exists.create.button" : {
-      "comment" : "Duplicate Phrase alert create duplicate button.  Pressing this button will allow for multiple categories with the same title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء نسخة مكررة"
+    "phrase_editor.alert.phrase_name_exists.create.button": {
+      "comment": "Duplicate Phrase alert create duplicate button.  Pressing this button will allow for multiple categories with the same title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء نسخة مكررة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret dublet"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret dublet"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duplizieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplizieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Duplicate"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Duplicate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear duplicado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear duplicado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer un doublon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer un doublon"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डुप्लिकेट बनाएं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डुप्लिकेट बनाएं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea duplicato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea duplicato"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중복 생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중복 생성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать дубликат"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать дубликат"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo bản sao"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo bản sao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建副本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建副本"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "創建副本"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創建副本"
           }
         }
       }
     },
-    "phrase_editor.alert.phrase_name_exists.title" : {
-      "comment" : "Duplicate Phrase alert text.  This text appears in an alert when a phrase is created with the same text as an existing phrase within the same category.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذه العبارة موجودة بالفعل. هل ترغب في إنشاء نسخة مكررة؟"
+    "phrase_editor.alert.phrase_name_exists.title": {
+      "comment": "Duplicate Phrase alert text.  This text appears in an alert when a phrase is created with the same text as an existing phrase within the same category.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه العبارة موجودة بالفعل. هل ترغب في إنشاء نسخة مكررة؟"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Denne sætning findes allerede. Vil du oprette en dublet?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne sætning findes allerede. Vil du oprette en dublet?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diesen Satz gibt es schon. Möchten Sie in duplizieren?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Satz gibt es schon. Möchten Sie in duplizieren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This phrase already exists. Would you like to create a duplicate?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This phrase already exists. Would you like to create a duplicate?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta frase ya existe. ¿Le gustaría crear un duplicado?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta frase ya existe. ¿Le gustaría crear un duplicado?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette expression existe déjà. Souhaitez-vous créer un doublon ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette expression existe déjà. Souhaitez-vous créer un doublon ?"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह वाक्यांश पहले से मौजूद है। क्या आप डुप्लीकेट बनाना चाहेंगे?"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह वाक्यांश पहले से मौजूद है। क्या आप डुप्लीकेट बनाना चाहेंगे?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questa frase esiste già. Creare un duplicato?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa frase esiste già. Creare un duplicato?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 문구는 이미 존재합니다. 복제본을 생성하시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 문구는 이미 존재합니다. 복제본을 생성하시겠습니까?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эта фраза уже существует. Хотите создать дубликат?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта фраза уже существует. Хотите создать дубликат?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cụm từ này đã tồn tại. Bạn có muốn tạo một bản sao không?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cụm từ này đã tồn tại. Bạn có muốn tạo một bản sao không?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此短语已经存在。您想要创建重复吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此短语已经存在。您想要创建重复吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這句話已經存在。您想創建一個副本嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這句話已經存在。您想創建一個副本嗎？"
           }
         }
       }
     },
-    "phrase_editor.toast.successfully_saved_to_favorites.title_format" : {
-      "comment" : "Informs the user that their newly-created phrase was successfully saved. The variable parameter is the name of the category that the phrase was saved to.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تم الحفظ إلى %@"
+    "phrase_editor.toast.successfully_saved_to_favorites.title_format": {
+      "comment": "Informs the user that their newly-created phrase was successfully saved. The variable parameter is the name of the category that the phrase was saved to.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم الحفظ إلى %@"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gemt til %@"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemt til %@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In %@ gespeichert"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In %@ gespeichert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saved to %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved to %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardado en %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado en %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistré dans %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré dans %@"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ में सहेजा गया"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ में सहेजा गया"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salvato in %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvato in %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@에 저장됨"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에 저장됨"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сохранено в %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранено в %@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã lưu vào %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã lưu vào %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存到 %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存到 %@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已保存到 %@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已保存到 %@"
           }
         }
       }
     },
-    "preset.category.add.phrase.title" : {
-      "comment" : "Add phrase to category button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أضف عبارة"
+    "preset.category.add.phrase.title": {
+      "comment": "Add phrase to category button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أضف عبارة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilføj sætning"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilføj sætning"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Satz hinzufügen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Satz hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Phrase"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Phrase"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar frase"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar frase"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter une expression"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une expression"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "वाक्यांश जोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक्यांश जोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi frase"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi frase"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구문 추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구문 추가"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить фразу"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить фразу"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm cụm từ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thêm cụm từ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加短语"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加短语"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加短語"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加短語"
           }
         }
       }
     },
-    "preset.category.numberpad.phrase.no.title" : {
-      "comment" : "'No' num pad response",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا"
+    "preset.category.numberpad.phrase.no.title": {
+      "comment": "'No' num pad response",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nej"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nej"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nein"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नहीं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नहीं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아니오"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아니오"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不是"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不是"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不"
           }
         }
       }
     },
-    "preset.category.numberpad.phrase.yes.title" : {
-      "comment" : "'Yes' num pad response",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نعم"
+    "preset.category.numberpad.phrase.yes.title": {
+      "comment": "'Yes' num pad response",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نعم"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ja"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ja"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sí"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sí"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oui"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oui"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हाँ"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हाँ"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Да"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Да"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đúng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đúng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "是"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "是"
           }
         }
       }
     },
-    "recents_empty_state.body.title" : {
-      "comment" : "Recents empty state body string.  This will appear in the Recents Category if no phrases have been used yet.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ابدأ في استخدام Vocable لرؤية أحدث العبارات المستخدمة هنا."
+    "recents_empty_state.body.title": {
+      "comment": "Recents empty state body string.  This will appear in the Recents Category if no phrases have been used yet.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابدأ في استخدام Vocable لرؤية أحدث العبارات المستخدمة هنا."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Begynd at bruge Vocable for at se dine senest brugte sætninger her."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Begynd at bruge Vocable for at se dine senest brugte sætninger her."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie Vocable benutzt haben, erscheinen Ihre zuletzt genutzten Sätze hier."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie Vocable benutzt haben, erscheinen Ihre zuletzt genutzten Sätze hier."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start using Vocable to see your most recently used phrases here."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start using Vocable to see your most recently used phrases here."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empieza a usar Vocable para ver tus frases usadas más recientemente aquí."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empieza a usar Vocable para ver tus frases usadas más recientemente aquí."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commencez à utiliser Vocable pour voir vos phrases les plus récemment utilisées ici."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencez à utiliser Vocable pour voir vos phrases les plus récemment utilisées ici."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अपने सबसे हाल ही में उपयोग किए गए वाक्यांशों को यहां देखने के लिए वोकेबल का उपयोग करना प्रारंभ करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपने सबसे हाल ही में उपयोग किए गए वाक्यांशों को यहां देखने के लिए वोकेबल का उपयोग करना प्रारंभ करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inizia a usare Vocable per vedere le tue frasi usate più di recente qui."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia a usare Vocable per vedere le tue frasi usate più di recente qui."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "여기에서 가장 최근에 사용한 문구를 보려면 Vocable을 사용하세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기에서 가장 최근에 사용한 문구를 보려면 Vocable을 사용하세요."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Начните использовать Vocable, чтобы увидеть здесь свои последние использованные фразы."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начните использовать Vocable, чтобы увидеть здесь свои последние использованные фразы."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bắt đầu sử dụng Vocable để xem các cụm từ được sử dụng gần đây nhất của bạn tại đây."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu sử dụng Vocable để xem các cụm từ được sử dụng gần đây nhất của bạn tại đây."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始使用 Vocable 在此处查看您最近使用的短语。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始使用 Vocable 在此处查看您最近使用的短语。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始使用 Vocable 在此處查看您最近使用的短語。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始使用 Vocable 在此處查看您最近使用的短語。"
           }
         }
       }
     },
-    "recents_empty_state.header.title" : {
-      "comment" : "Recents empty state title string.  This will appear in the Recents Category if no phrases have been used yet.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد عبارات مستخدمة مؤخرًا"
+    "recents_empty_state.header.title": {
+      "comment": "Recents empty state title string.  This will appear in the Recents Category if no phrases have been used yet.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد عبارات مستخدمة مؤخرًا"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen nyligt anvendte sætninger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen nyligt anvendte sætninger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es gibt keine zuletzt genutzten Sätze"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es gibt keine zuletzt genutzten Sätze"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No recently used phrases"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No recently used phrases"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay frases usadas recientemente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay frases usadas recientemente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune expression récemment utilisée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune expression récemment utilisée"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हाल ही में प्रयुक्त वाक्यांश नहीं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हाल ही में प्रयुक्त वाक्यांश नहीं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna frase usata di recente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna frase usata di recente"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "최근에 사용한 문구가 없습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근에 사용한 문구가 없습니다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет недавно использованных фраз"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет недавно использованных фраз"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có cụm từ được sử dụng gần đây"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có cụm từ được sử dụng gần đây"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有最近使用的短语"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有最近使用的短语"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有最近使用的短語"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有最近使用的短語"
           }
         }
       }
     },
-    "selection_mode.header.title" : {
-      "comment" : "Selection mode setting header title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع التحديد"
+    "selection_mode.header.title": {
+      "comment": "Selection mode setting header title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع التحديد"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Markeringstilstand"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markeringstilstand"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steuerungsmodus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steuerungsmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selection Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selection Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de selección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de selección"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode de sélection"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode de sélection"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "चयन मोड"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चयन मोड"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità selezione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità selezione"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 모드"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим выбора"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим выбора"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ Lựa chọn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ Lựa chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动对象模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移动对象模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇模式"
           }
         }
       }
     },
-    "settings.alert.no_email_configured.button.dismiss.title" : {
-      "comment" : "No email account configured error alert dismiss button title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تماماً"
+    "settings.alert.no_email_configured.button.dismiss.title": {
+      "comment": "No email account configured error alert dismiss button title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تماماً"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ठीक है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хорошо"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хорошо"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         }
       }
     },
-    "settings.alert.no_email_configured.title" : {
-      "comment" : "No email account configured error alert title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الرجاء تسجيل الدخول إلى حساب بالبريد لـ %1$@."
+    "settings.alert.no_email_configured.title": {
+      "comment": "No email account configured error alert title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرجاء تسجيل الدخول إلى حساب بالبريد لـ %1$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log venligst på en konto med Mail for %1$@."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log venligst på en konto med Mail for %1$@."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte melden Sie sich bei einem Konto mit Mail für %1$@ an."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte melden Sie sich bei einem Konto mit Mail für %1$@ an."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please sign into an account with Mail for %1$@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please sign into an account with Mail for %1$@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, inicia sesión en una cuenta con Mail para %1$@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, inicia sesión en una cuenta con Mail para %1$@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez vous connecter à un compte avec Mail pour %1$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veuillez vous connecter à un compte avec Mail pour %1$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कृपया %1$@ के लिए मेल के साथ एक खाते में साइन इन करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कृपया %1$@ के लिए मेल के साथ एक खाते में साइन इन करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per favore accedi a un account con Mail per %1$@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per favore accedi a un account con Mail per %1$@."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@의 Mail 계정에 로그인하십시오."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@의 Mail 계정에 로그인하십시오."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пожалуйста, войдите в аккаунт Mail для %1$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожалуйста, войдите в аккаунт Mail для %1$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please sign into an account with Mail for %1$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please sign into an account with Mail for %1$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请使用 %1$@ 邮件应用程序登录您的电子邮件帐户"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请使用 %1$@ 邮件应用程序登录您的电子邮件帐户"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請使用 Mail 登錄 %1$@ 的帳戶。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請使用 Mail 登錄 %1$@ 的帳戶。"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_confirmation.body" : {
-      "comment" : "Reset setting alert confirmation prompt",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هل أنت متأكد من أنك تريد إعادة تعيين Vocable إلى الإعدادات لافتراضية؟ لا يمكن التراجع عن هذا الإجراء."
+    "settings.alert.reset_app_settings_confirmation.body": {
+      "comment": "Reset setting alert confirmation prompt",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل أنت متأكد من أنك تريد إعادة تعيين Vocable إلى الإعدادات لافتراضية؟ لا يمكن التراجع عن هذا الإجراء."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er du sikker på, at du vil nulstille Vocable til standardindstillinger? Denne handling kan ikke fortrydes."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Er du sikker på, at du vil nulstille Vocable til standardindstillinger? Denne handling kan ikke fortrydes."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sind Sie sicher, dass Sie Vocable auf Werkseinstellungen zurücksetzen möchten? Dies kann nicht rückgängig gemacht werden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sind Sie sicher, dass Sie Vocable auf Werkseinstellungen zurücksetzen möchten? Dies kann nicht rückgängig gemacht werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to reset Vocable to default settings? This action cannot be undone."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to reset Vocable to default settings? This action cannot be undone."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Está seguro de que desea restablecer Vocable a la configuración predeterminada? Esta acción no se puede deshacer."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Está seguro de que desea restablecer Vocable a la configuración predeterminada? Esta acción no se puede deshacer."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voulez-vous vraiment réinitialiser Vocable aux paramètres par défaut ? Cette action ne peut pas être annulée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voulez-vous vraiment réinitialiser Vocable aux paramètres par défaut ? Cette action ne peut pas être annulée."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "क्या आप वाकई वोकेबल को डिफ़ॉल्ट सेटिंग्स पर रीसेट करना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्या आप वाकई वोकेबल को डिफ़ॉल्ट सेटिंग्स पर रीसेट करना चाहते हैं? इस क्रिया को पूर्ववत नहीं किया जा सकता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sei sicuro di voler reimpostare Vocable alle impostazioni predefinite? Questa azione non può essere annullata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei sicuro di voler reimpostare Vocable alle impostazioni predefinite? Questa azione non può essere annullata."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable을 기본 설정으로 재설정하시겠습니까? 이 작업은 취소할 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable을 기본 설정으로 재설정하시겠습니까? 이 작업은 취소할 수 없습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы уверены, что хотите сбросить Vocable до настроек по умолчанию? Это действие не может быть отменено."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы уверены, что хотите сбросить Vocable до настроек по умолчанию? Это действие не может быть отменено."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có chắc chắn muốn đặt lại Vocable về cài đặt mặc định không? Hành động này không thể được hoàn tác."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có chắc chắn muốn đặt lại Vocable về cài đặt mặc định không? Hành động này không thể được hoàn tác."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您确定要将 Vocable 重置为默认设置吗？此操作无法撤消。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您确定要将 Vocable 重置为默认设置吗？此操作无法撤消。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您確定要將 Voable 重置為默認設置嗎？此操作無法撤消。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您確定要將 Voable 重置為默認設置嗎？此操作無法撤消。"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_confirmation.button.cancel.title" : {
-      "comment" : "Reset setting alert Cancel button.  This will cancel the reset operation.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "settings.alert.reset_app_settings_confirmation.button.cancel.title": {
+      "comment": "Reset setting alert Cancel button.  This will cancel the reset operation.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_confirmation.button.confirm.title" : {
-      "comment" : "Reset setting alert settings Reset button.  This will continue with the reset operation.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة تعيين"
+    "settings.alert.reset_app_settings_confirmation.button.confirm.title": {
+      "comment": "Reset setting alert settings Reset button.  This will continue with the reset operation.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nulstil"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nulstil"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurücksetzen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रीसेट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रीसेट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Azzera"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azzera"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "초기화"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초기화"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезагрузить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезагрузить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài lại"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重 置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重 置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_failure.body" : {
-      "comment" : "Reset app settings failure alert",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فشل إعادة تعيين Vocable. يرجى المحاولة مرة أخرى أو إعادة تثبيت Vocable إذا استمرت المشكلة."
+    "settings.alert.reset_app_settings_failure.body": {
+      "comment": "Reset app settings failure alert",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فشل إعادة تعيين Vocable. يرجى المحاولة مرة أخرى أو إعادة تثبيت Vocable إذا استمرت المشكلة."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable kunne ikke nulstilles. Prøv igen, eller geninstaller Vocable hvis problemet fortsætter."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable kunne ikke nulstilles. Prøv igen, eller geninstaller Vocable hvis problemet fortsætter."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut oder installieren Sie Vocable neu, sollte der Fehler bestehen bleiben."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable konnte nicht zurückgesetzt werden. Bitte versuchen Sie es erneut oder installieren Sie Vocable neu, sollte der Fehler bestehen bleiben."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable failed to reset. Please try again or reinstall Vocable if the issue persists."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable failed to reset. Please try again or reinstall Vocable if the issue persists."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable no se pudo restablecer. Por favor, inténtelo de nuevo o reinstale Vocable si el problema persiste."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable no se pudo restablecer. Por favor, inténtelo de nuevo o reinstale Vocable si el problema persiste."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable n'a pas pu être réinitialisé. Veuillez réessayer ou réinstaller Vocable si le problème persiste."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable n'a pas pu être réinitialisé. Veuillez réessayer ou réinstaller Vocable si le problème persiste."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable रीसेट करने में विफल रहा। कृपया पुन: प्रयास करें या यदि समस्या बनी रहती है तो Vocable को पुन: स्थापित करें।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable रीसेट करने में विफल रहा। कृपया पुन: प्रयास करें या यदि समस्या बनी रहती है तो Vocable को पुन: स्थापित करें।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile ripristinare la voce. Riprova o reinstalla Vocable se il problema persiste."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile ripristinare la voce. Riprova o reinstalla Vocable se il problema persiste."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성을 재설정하지 못했습니다. 다시 시도하거나 문제가 지속되면 Vocable을 다시 설치하십시오."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성을 재설정하지 못했습니다. 다시 시도하거나 문제가 지속되면 Vocable을 다시 설치하십시오."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable не удалось сбросить. Повторите попытку или переустановите Vocable, если проблема не устранена."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable не удалось сбросить. Повторите попытку или переустановите Vocable, если проблема не устранена."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể đặt lại Vocable. Vui lòng thử lại hoặc cài đặt lại Vocable nếu sự cố vẫn tiếp diễn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể đặt lại Vocable. Vui lòng thử lại hoặc cài đặt lại Vocable nếu sự cố vẫn tiếp diễn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语音无法重置。如果问题仍然存在，请重试或重新安装 Vocable。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语音无法重置。如果问题仍然存在，请重试或重新安装 Vocable。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語音無法重置。如果問題仍然存在，請重試或重新安裝 Vocable。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語音無法重置。如果問題仍然存在，請重試或重新安裝 Vocable。"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_failure.button.ok" : {
-      "comment" : "Button to dismiss the Reset app failure alert",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تماماً"
+    "settings.alert.reset_app_settings_failure.button.ok": {
+      "comment": "Button to dismiss the Reset app failure alert",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تماماً"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ठीक है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хорошо"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хорошо"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_success.body" : {
-      "comment" : "Reset app settings success alert",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تمت إعادة تعيين Vocable بنجاح."
+    "settings.alert.reset_app_settings_success.body": {
+      "comment": "Reset app settings success alert",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمت إعادة تعيين Vocable بنجاح."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable er blevet nulstillet med succes."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable er blevet nulstillet med succes."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable wurde erfolgreich zurückgesetzt."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable wurde erfolgreich zurückgesetzt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable has been reset successfully."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable has been reset successfully."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable se ha restablecido correctamente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable se ha restablecido correctamente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable a été réinitialisé avec succès."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable a été réinitialisé avec succès."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable को सफलतापूर्वक रीसेट कर दिया गया है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable को सफलतापूर्वक रीसेट कर दिया गया है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable è stato resettato con successo."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable è stato resettato con successo."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성이 성공적으로 재설정되었습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성이 성공적으로 재설정되었습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable успешно сброшен."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable успешно сброшен."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable đã được đặt lại thành công."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable đã được đặt lại thành công."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已成功恢复默认设置."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已成功恢复默认设置."
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詞彙已成功重置。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詞彙已成功重置。"
           }
         }
       }
     },
-    "settings.alert.reset_app_settings_success.button.ok" : {
-      "comment" : "Button to dismiss the Reset app success alert",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تماماً"
+    "settings.alert.reset_app_settings_success.button.ok": {
+      "comment": "Button to dismiss the Reset app success alert",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تماماً"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ठीक है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хорошо"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хорошо"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "好的"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好的"
           }
         }
       }
     },
-    "settings.alert.surrender_gaze_confirmation.body" : {
-      "comment" : "Body of confirmation alert shown when user is about to navigate to a destination where Vocable's head tracking will not be available.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أنت على وشك مغادرة تطبيق Vocable. قد تفقد التحكم في تتبع الرأس."
+    "settings.alert.surrender_gaze_confirmation.body": {
+      "comment": "Body of confirmation alert shown when user is about to navigate to a destination where Vocable's head tracking will not be available.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أنت على وشك مغادرة تطبيق Vocable. قد تفقد التحكم في تتبع الرأس."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du er ved at forlade Vocable. Du vil måske miste hovedsporingskontrol."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du er ved at forlade Vocable. Du vil måske miste hovedsporingskontrol."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du bist dabei die Vocable App zu verlassen. Du kannst die Kopfverfolgungskontrolle verlieren."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist dabei die Vocable App zu verlassen. Du kannst die Kopfverfolgungskontrolle verlieren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You're about to leave the Vocable app. You may lose head tracking control."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You're about to leave the Vocable app. You may lose head tracking control."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estás a punto de salir de la aplicación Vocable. Puede perder el control de seguimiento de la cabeza."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estás a punto de salir de la aplicación Vocable. Puede perder el control de seguimiento de la cabeza."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous êtes sur le point de quitter l'application Vocable. Vous risquez de perdre le contrôle du suivi de la tête."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes sur le point de quitter l'application Vocable. Vous risquez de perdre le contrôle du suivi de la tête."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आप वोकेबल ऐप छोड़ने वाले हैं। आप हेड ट्रैकिंग नियंत्रण खो सकते हैं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आप वोकेबल ऐप छोड़ने वाले हैं। आप हेड ट्रैकिंग नियंत्रण खो सकते हैं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stai per uscire dall'app Vocable. Potresti perdere il controllo del rilevamento della testa."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stai per uscire dall'app Vocable. Potresti perdere il controllo del rilevamento della testa."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable 앱을 종료하려고 합니다. 머리 추적 제어를 잃을 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable 앱을 종료하려고 합니다. 머리 추적 제어를 잃을 수 있습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы собираетесь покинуть приложение Vocable. Вы можете потерять контроль над отслеживанием головы."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы собираетесь покинуть приложение Vocable. Вы можете потерять контроль над отслеживанием головы."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn sắp rời khỏi ứng dụng Vocable. Bạn có thể mất kiểm soát theo dõi đầu."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn sắp rời khỏi ứng dụng Vocable. Bạn có thể mất kiểm soát theo dõi đầu."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您即将被带到可说话之外。您可能会失去头部跟踪控制。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您即将被带到可说话之外。您可能会失去头部跟踪控制。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您即將離開 Vocable 應用程序。您可能會失去頭部跟踪控制。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您即將離開 Vocable 應用程序。您可能會失去頭部跟踪控制。"
           }
         }
       }
     },
-    "settings.alert.surrender_gaze_confirmation.button.cancel.title" : {
-      "comment" : "Button cancelling the action that would have taken them away from the head tracking-navigable portion of the app",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "settings.alert.surrender_gaze_confirmation.button.cancel.title": {
+      "comment": "Button cancelling the action that would have taken them away from the head tracking-navigable portion of the app",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "settings.alert.surrender_gaze_confirmation.button.confirm.title" : {
-      "comment" : "Button confirming that the user would like to navigate away from the head tracking-navigable portion of the app",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تأكيد"
+    "settings.alert.surrender_gaze_confirmation.button.confirm.title": {
+      "comment": "Button confirming that the user would like to navigate away from the head tracking-navigable portion of the app",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأكيد"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bekræft"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bekræft"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestätigen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bestätigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirm"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirmer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confirmer"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "पुष्टि करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पुष्टि करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confermare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Confermare"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인하다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인하다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подтвердить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтвердить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xác nhận"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xác nhận"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确认"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "確認"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認"
           }
         }
       }
     },
-    "settings.cell.categories.title" : {
-      "comment" : "edit categories settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الفئات والعبارات"
+    "settings.cell.categories.title": {
+      "comment": "edit categories settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفئات والعبارات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorier og sætning"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorier og sætning"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kategorien und Phrasen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kategorien und Phrasen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categories and Phrases"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categories and Phrases"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categorías y frases"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorías y frases"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catégories et phrases"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catégories et phrases"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "श्रेणियाँ और वाक्यांश"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "श्रेणियाँ और वाक्यांश"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Categorie e frasi"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Categorie e frasi"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카테고리 및 구문"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카테고리 및 구문"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Категории и фразы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Категории и фразы"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danh mục và Cụm từ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danh mục và Cụm từ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "类别和词组"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类别和词组"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "類別和短語"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "類別和短語"
           }
         }
       }
     },
-    "settings.cell.contact_developers.title" : {
-      "comment" : "contact developers settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تواصل مع المطورين"
+    "settings.cell.contact_developers.title": {
+      "comment": "contact developers settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تواصل مع المطورين"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontakt Udvikler"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontakt Udvikler"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entwickler kontaktieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entwickler kontaktieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact Developers"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Developers"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contactar desarrolladores"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contactar desarrolladores"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contacter les développeurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contacter les développeurs"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डेवलपर से संपर्क करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डेवलपर से संपर्क करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contattare gli sviluppatori"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contattare gli sviluppatori"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개발자에게 문의"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개발자에게 문의"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Связаться с разработчиками"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Связаться с разработчиками"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danh mục và Cụm từ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danh mục và Cụm từ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "联系开发者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "联系开发者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聯繫開發者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聯繫開發者"
           }
         }
       }
     },
-    "settings.cell.head_tracking.title" : {
-      "comment" : "Option within Selectin Mode.  This option is to enable to disable head tracking via a toggle.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعقب الرأس"
+    "settings.cell.head_tracking.title": {
+      "comment": "Option within Selectin Mode.  This option is to enable to disable head tracking via a toggle.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعقب الرأس"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hovedbevægelsesregistrering"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hovedbevægelsesregistrering"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per Kopfbewegung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per Kopfbewegung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Head Tracking"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Head Tracking"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seguimiento de la cabeza"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seguimiento de la cabeza"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suivi de la tête"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suivi de la tête"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "हेड ट्रैकिंग"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हेड ट्रैकिंग"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controllo tramite movimenti della testa"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controllo tramite movimenti della testa"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "헤드 트래킹"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "헤드 트래킹"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отслеживание головы"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отслеживание головы"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theo dõi đầu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theo dõi đầu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "头部跟踪"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "头部跟踪"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "頭部追踪"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "頭部追踪"
           }
         }
       }
     },
-    "settings.cell.keyboard_layout.title" : {
-      "comment" : "edit keyboard layout settings menu item",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ﻡ/ﻝ ﻂﻴﻄﺨﺗ"
+    "settings.cell.keyboard_layout.title": {
+      "comment": "edit keyboard layout settings menu item",
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ﻡ/ﻝ ﻂﻴﻄﺨﺗ"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturlayout"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturlayout"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturlayout"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturlayout"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard Layout"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard Layout"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diseño del Teclado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño del Teclado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disposition Clavier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition Clavier"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कुंजीपटल अभिन्यास"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजीपटल अभिन्यास"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Layout tastiera"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout tastiera"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "키보드 자판의 키 배열"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 자판의 키 배열"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Раскладка клавиатуры"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раскладка клавиатуры"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bố trí bàn phím"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố trí bàn phím"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "键盘布局"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键盘布局"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鍵盤佈局"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤佈局"
           }
         }
       }
     },
-    "settings.cell.listening_mode.title" : {
-      "comment" : "Listening Mode root settings menu item. Navigates the user to the Listening Mode settings screen where they can configure their preferences for listening mode.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع الاستماع"
+    "settings.cell.listening_mode.title": {
+      "comment": "Listening Mode root settings menu item. Navigates the user to the Listening Mode settings screen where they can configure their preferences for listening mode.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع الاستماع"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyttefunktion"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyttefunktion"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hörmodus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de escucha"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de escucha"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode d'écoute"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode d'écoute"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सुनने का तरीका"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनने का तरीका"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità di ascolto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità di ascolto"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "듣기 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "듣기 모드"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим прослушивания"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим прослушивания"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ nghe"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ nghe"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在侦听模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在侦听模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聆聽模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聆聽模式"
           }
         }
       }
     },
-    "settings.cell.privacy_policy.title" : {
-      "comment" : "view privacy policy settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حقوق الخصوصية"
+    "settings.cell.privacy_policy.title": {
+      "comment": "view privacy policy settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حقوق الخصوصية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privatlivspolitik"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privatlivspolitik"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datenschutz"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenschutz"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy Policy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Política de privacidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Política de privacidad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Politique de confidentialité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politique de confidentialité"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "गोपनीयता नीति"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोपनीयता नीति"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Politica sulla privacy"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Politica sulla privacy"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인정보 취급 약관"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인정보 취급 약관"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Политика конфиденциальности"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Политика конфиденциальности"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chính sách bảo mật"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chính sách bảo mật"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隐私政策"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐私政策"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "隱私政策"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱私政策"
           }
         }
       }
     },
-    "settings.cell.qwerty_layout.title" : {
-      "comment" : "Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "كويرتي مدمجة"
+    "settings.cell.qwerty_layout.title": {
+      "comment": "Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كويرتي مدمجة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kompakt QWERTY"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kompakt QWERTY"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kompakt QWERTY"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kompakt QWERTY"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compact QWERTY"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compact QWERTY"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QWERTY de Compacto"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QWERTY de Compacto"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QWERTY compacte"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QWERTY compacte"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कॉम्पैक्ट क्वर्टी"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉम्पैक्ट क्वर्टी"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QWERTY Compatto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QWERTY Compatto"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "콤팩트 QWERTY"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "콤팩트 QWERTY"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Компактный QWERTY"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Компактный QWERTY"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "QWERTY nhỏ gọn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QWERTY nhỏ gọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简洁的QWERTY"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简洁的QWERTY"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "緊湊型全鍵盤"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "緊湊型全鍵盤"
           }
         }
       }
     },
-    "settings.cell.reset_all.title" : {
-      "comment" : "reset all settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "العودة إلي إعدادات التطبيق"
+    "settings.cell.reset_all.title": {
+      "comment": "reset all settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "العودة إلي إعدادات التطبيق"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nulstil App Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nulstil App Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Einstellungen zurücksetzen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Einstellungen zurücksetzen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset App Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset App Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer configuración"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer configuración"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser les paramètres de l'application"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser les paramètres de l'application"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स रीसेट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स रीसेट करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ripristina le impostazioni dell'app"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina le impostazioni dell'app"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱 설정 재설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 설정 재설정"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить настройки приложения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить настройки приложения"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đặt lại cài đặt ứng dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại cài đặt ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置应用设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置应用设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置應用設置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置應用設置"
           }
         }
       }
     },
-    "settings.cell.selection_mode.title" : {
-      "comment" : "edit cursor selection mode settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع التحديد"
+    "settings.cell.selection_mode.title": {
+      "comment": "edit cursor selection mode settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع التحديد"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Markeringstilstand"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markeringstilstand"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steuerungsmodus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steuerungsmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selection Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selection Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de selección"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de selección"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode de sélection"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode de sélection"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "चयन मोड"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चयन मोड"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità selezione"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità selezione"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 모드"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим выбора"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим выбора"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ Lựa chọn"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ Lựa chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "移动对象模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移动对象模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇模式"
           }
         }
       }
     },
-    "settings.cell.timing_sensitivity.title" : {
-      "comment" : "edit cursor timing and sensititivy settings menu item",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التوقيت و الحساسية"
+    "settings.cell.timing_sensitivity.title": {
+      "comment": "edit cursor timing and sensititivy settings menu item",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التوقيت و الحساسية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing og Følsomhed"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing og Følsomhed"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing und Empfindlichkeit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing und Empfindlichkeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing and Sensitivity"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing and Sensitivity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiempo y sensibilidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiempo y sensibilidad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing et Sensibilité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing et Sensibilité"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "समय और संवेदनशीलता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समय और संवेदनशीलता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempistiche e sensibilità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tempistiche e sensibilità"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "타이밍과 감도"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타이밍과 감도"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Время и чувствительность"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время и чувствительность"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thời gian và độ nhạy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thời gian và độ nhạy"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "时间和灵敏度"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间和灵敏度"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "時間和靈敏度"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時間和靈敏度"
           }
         }
       }
     },
-    "settings.cell.voice_configuration.title" : {
-      "comment" : "Settings option title for row that navigates to the Voice settings screen",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "صوت"
+    "settings.cell.voice_configuration.title": {
+      "comment": "Settings option title for row that navigates to the Voice settings screen",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صوت"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stemme"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stemme"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimme"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voice"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज़"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज़"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voce"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разговор"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разговор"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "嗓音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "嗓音"
           }
         }
       }
     },
-    "settings.header.title" : {
-      "comment" : "Settings screen header title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإعدادات"
+    "settings.header.title": {
+      "comment": "Settings screen header title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indstillinger"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paramètres"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सेटिंग्स"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設置"
           }
         }
       }
     },
-    "settings.keyboard_layout.header.title" : {
-      "comment" : "Keyboard Layout setting header title",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ﻡ/ﻝ ﻂﻴﻄﺨﺗ"
+    "settings.keyboard_layout.header.title": {
+      "comment": "Keyboard Layout setting header title",
+      "extractionState": "stale",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ﻡ/ﻝ ﻂﻴﻄﺨﺗ"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturlayout"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturlayout"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturlayout"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturlayout"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keyboard Layout"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keyboard Layout"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diseño del Teclado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diseño del Teclado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disposition Clavier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition Clavier"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कुंजीपटल अभिन्यास"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजीपटल अभिन्यास"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Layout tastiera"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout tastiera"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "키보드 자판의 키 배열"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 자판의 키 배열"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Раскладка клавиатуры"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раскладка клавиатуры"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bố trí bàn phím"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố trí bàn phím"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "键盘布局"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键盘布局"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鍵盤佈局"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤佈局"
           }
         }
       }
     },
-    "settings.keyboard_layout.qwerty_layout.explanation_footer" : {
-      "comment" : "Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "استخدم تخطيط لوحة المفاتيح QWERTY في جميع الاتجاهات. قد تكون المفاتيح أصغر حجمًا، مما يجعل الكتابة أكثر صعوبة."
+    "settings.keyboard_layout.qwerty_layout.explanation_footer": {
+      "comment": "Option within Keyboard Layout. This option is to enable or disable QWERTY keyboard on portrait iPhone.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدم تخطيط لوحة المفاتيح QWERTY في جميع الاتجاهات. قد تكون المفاتيح أصغر حجمًا، مما يجعل الكتابة أكثر صعوبة."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brug QWERTY tastaturlayout i alle retninger. Taster kan være mindre, hvilket gør det sværere at skrive dem."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brug QWERTY tastaturlayout i alle retninger. Taster kan være mindre, hvilket gør det sværere at skrive dem."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwenden Sie in allen Ausrichtungen das QWERTZ-Tastaturlayout. Die Tasten können kleiner sein, was das Tippen erschwert."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwenden Sie in allen Ausrichtungen das QWERTZ-Tastaturlayout. Die Tasten können kleiner sein, was das Tippen erschwert."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use QWERTY keyboard layout in all orientations. Keys may be smaller, making typing more difficult."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use QWERTY keyboard layout in all orientations. Keys may be smaller, making typing more difficult."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilice la distribución del teclado QWERTY en todas las orientaciones. Las teclas pueden ser más pequeñas, lo que dificulta la escritura."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilice la distribución del teclado QWERTY en todas las orientaciones. Las teclas pueden ser más pequeñas, lo que dificulta la escritura."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisez la disposition du clavier QWERTY dans toutes les orientations. Les touches peuvent être plus petites, ce qui rend la saisie plus difficile."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisez la disposition du clavier QWERTY dans toutes les orientations. Les touches peuvent être plus petites, ce qui rend la saisie plus difficile."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सभी ओरिएंटेशन में QWERTY कीबोर्ड लेआउट का उपयोग करें। कुंजियाँ छोटी हो सकती हैं, जिससे टाइपिंग अधिक कठिन हो जाएगी।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी ओरिएंटेशन में QWERTY कीबोर्ड लेआउट का उपयोग करें। कुंजियाँ छोटी हो सकती हैं, जिससे टाइपिंग अधिक कठिन हो जाएगी।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilizza il layout della tastiera QWERTY in tutti gli orientamenti. I tasti potrebbero essere più piccoli, rendendo la digitazione più difficile."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilizza il layout della tastiera QWERTY in tutti gli orientamenti. I tasti potrebbero essere più piccoli, rendendo la digitazione più difficile."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 방향에서 QWERTY 키보드 레이아웃을 사용합니다. 키가 작아서 타이핑이 더 어려워질 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 방향에서 QWERTY 키보드 레이아웃을 사용합니다. 키가 작아서 타이핑이 더 어려워질 수 있습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Используйте раскладку клавиатуры QWERTY во всех ориентациях. Клавиши могут быть меньше, что затрудняет набор текста."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Используйте раскладку клавиатуры QWERTY во всех ориентациях. Клавиши могут быть меньше, что затрудняет набор текста."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sử dụng bố cục bàn phím QWERTY ở mọi hướng. Các phím có thể nhỏ hơn, khiến việc gõ phím trở nên khó khăn hơn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sử dụng bố cục bàn phím QWERTY ở mọi hướng. Các phím có thể nhỏ hơn, khiến việc gõ phím trở nên khó khăn hơn."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在所有方向使用 QWERTY 键盘布局。键盘可能较小，更难打字。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在所有方向使用 QWERTY 键盘布局。键盘可能较小，更难打字。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在所有方向上使用 QWERTY 鍵盤佈局。 按鍵可能更小，使打字更加困難。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在所有方向上使用 QWERTY 鍵盤佈局。 按鍵可能更小，使打字更加困難。"
           }
         }
       }
     },
-    "settings.listening_mode.device_unsupported_explanation_footer" : {
-      "comment" : "Footer text displayed in the Listening Mode preferences screen. This is only displayed if the user's device does not support Listening Mode because of it's language or lack of neural engine.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذا %1$@ في %2$@ %3$@ لا يدعم وضع الاستماع.\n\nوضع الاستماع متاح حاليا باللغة الإنجليزية فقط ويتطلب تمكين %4$@."
+    "settings.listening_mode.device_unsupported_explanation_footer": {
+      "comment": "Footer text displayed in the Listening Mode preferences screen. This is only displayed if the user's device does not support Listening Mode because of it's language or lack of neural engine.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذا %1$@ في %2$@ %3$@ لا يدعم وضع الاستماع.\n\nوضع الاستماع متاح حاليا باللغة الإنجليزية فقط ويتطلب تمكين %4$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dette %1$@ på %2$@ %3$@ understøtter ikke Lyttetilstand.\n\nLyttetilstand er i øjeblikket kun tilgængelig på engelsk og kræver %4$@ for at være aktiveret."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dette %1$@ på %2$@ %3$@ understøtter ikke Lyttetilstand.\n\nLyttetilstand er i øjeblikket kun tilgængelig på engelsk og kræver %4$@ for at være aktiveret."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses %1$@ auf %2$@ %3$@ unterstützt den Zuhörmodus nicht.\n\nDer Hörmodus ist derzeit nur auf Englisch verfügbar und erfordert die Aktivierung von %4$@."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses %1$@ auf %2$@ %3$@ unterstützt den Zuhörmodus nicht.\n\nDer Hörmodus ist derzeit nur auf Englisch verfügbar und erfordert die Aktivierung von %4$@."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %4$@ to be enabled."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This %1$@ on %2$@ %3$@ does not support Listening Mode.\n\nListening Mode is currently only available in English and requires %4$@ to be enabled."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este %1$@ en %2$@ %3$@ no soporta el modo de escucha.\n\nEl modo de escucha solo está disponible actualmente en inglés y requiere que %4$@ esté habilitado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este %1$@ en %2$@ %3$@ no soporta el modo de escucha.\n\nEl modo de escucha solo está disponible actualmente en inglés y requiere que %4$@ esté habilitado."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le mode d'écoute.\n\nLe mode d'écoute n'est actuellement disponible qu'en anglais et nécessite l'activation de %4$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le mode d'écoute.\n\nLe mode d'écoute n'est actuellement disponible qu'en anglais et nécessite l'activation de %4$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@ पर यह %1$@ श्रवण मोड का समर्थन नहीं करता है।\n\nलिसनिंग मोड वर्तमान में केवल अंग्रेज़ी में उपलब्ध है और %4$@ को सक्षम करने की आवश्यकता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@ पर यह %1$@ श्रवण मोड का समर्थन नहीं करता है।\n\nलिसनिंग मोड वर्तमान में केवल अंग्रेज़ी में उपलब्ध है और %4$@ को सक्षम करने की आवश्यकता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo %1$@ su %2$@ %3$@ non supporta la modalità di ascolto.\n\nLa modalità di ascolto è attualmente disponibile solo in inglese e richiede %4$@ per essere abilitata."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo %1$@ su %2$@ %3$@ non supporta la modalità di ascolto.\n\nLa modalità di ascolto è attualmente disponibile solo in inglese e richiede %4$@ per essere abilitata."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@의 이 %1$@은(는) 듣기 모드를 지원하지 않습니다.\n\n듣기 모드는 현재 영어로만 제공되며 %4$@를 활성화해야 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@의 이 %1$@은(는) 듣기 모드를 지원하지 않습니다.\n\n듣기 모드는 현재 영어로만 제공되며 %4$@를 활성화해야 합니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этот %1$@ на %2$@ %3$@ не поддерживает режим прослушивания.\n\nРежим прослушивания в настоящее время доступен только на английском языке и требует включения %4$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот %1$@ на %2$@ %3$@ не поддерживает режим прослушивания.\n\nРежим прослушивания в настоящее время доступен только на английском языке и требует включения %4$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ trên %2$@ %3$@ này không hỗ trợ Chế độ nghe.\n\nChế độ nghe hiện chỉ khả dụng bằng tiếng Anh và yêu cầu bật %4$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ trên %2$@ %3$@ này không hỗ trợ Chế độ nghe.\n\nChế độ nghe hiện chỉ khả dụng bằng tiếng Anh và yêu cầu bật %4$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此 %1$@ 在 %2$@ %3$@ 不支持侦听模式。\n\n侦听模式目前仅有英文可用，需要启用 %4$@。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 %1$@ 在 %2$@ %3$@ 不支持侦听模式。\n\n侦听模式目前仅有英文可用，需要启用 %4$@。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@ 上的這個 %1$@ 不支持聆聽模式。\n\n聆聽模式目前僅提供英文版本，需要啟用 %4$@。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@ 上的這個 %1$@ 不支持聆聽模式。\n\n聆聽模式目前僅提供英文版本，需要啟用 %4$@。"
           }
         }
       }
     },
-    "settings.listening_mode.hot_word_toggle_cell.title" : {
-      "comment" : "Title of Listening Mode preferences cell that toggles \"Hey Vocable\" shortcut feature on or off when selected",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختصار \"Hey Vocable\""
+    "settings.listening_mode.hot_word_toggle_cell.title": {
+      "comment": "Title of Listening Mode preferences cell that toggles \"Hey Vocable\" shortcut feature on or off when selected",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختصار \"Hey Vocable\""
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Hey Vocable\" genvej"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Hey Vocable\" genvej"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Hallo Vocable\" Verknüpfung"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Hallo Vocable\" Verknüpfung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Hey Vocable\" shortcut"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Hey Vocable\" shortcut"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso directo \"Hey Vocable\""
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso directo \"Hey Vocable\""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raccourci \"Hey Vocable\""
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raccourci \"Hey Vocable\""
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Hey Vocable\" शॉर्टकट"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Hey Vocable\" शॉर्टकट"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scorciatoia \"Hey Vocable\""
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorciatoia \"Hey Vocable\""
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"Hey Vocable\" 단축키"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"Hey Vocable\" 단축키"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ярлык \"Hey Vocable\""
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ярлык \"Hey Vocable\""
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phím tắt \"Hey Vocable\""
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tắt \"Hey Vocable\""
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“嘿Vocable”快捷方式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“嘿Vocable”快捷方式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "“Hey Vocable”快捷方式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“Hey Vocable”快捷方式"
           }
         }
       }
     },
-    "settings.listening_mode.hotword_explanation_footer" : {
-      "comment" : "Footer text displayed in the Listening Mode preferences screen. This text describes the \"Hey Vocable\" feature, how it is activated, and how it automatically navigates the user to the Listening Mode screen.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "انتقل تلقائيًا إلى فئة وضع الاستماع عندما يسمع Vocable شخصًا يقول \"مرحبًا، Vocable\""
+    "settings.listening_mode.hotword_explanation_footer": {
+      "comment": "Footer text displayed in the Listening Mode preferences screen. This text describes the \"Hey Vocable\" feature, how it is activated, and how it automatically navigates the user to the Listening Mode screen.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتقل تلقائيًا إلى فئة وضع الاستماع عندما يسمع Vocable شخصًا يقول \"مرحبًا، Vocable\""
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Naviger automatisk til kategorien Lyttetilstand, når Vocable hører nogen sige \"Hey, Vocable\""
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naviger automatisk til kategorien Lyttetilstand, når Vocable hører nogen sige \"Hey, Vocable\""
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically navigate to the Listening Mode category when someone hears \"Hey, Vokable.\""
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically navigate to the Listening Mode category when someone hears \"Hey, Vokable.\""
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatically navigate to the Listening Mode category when Vocable hears someone say \"Hey, Vocable\""
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatically navigate to the Listening Mode category when Vocable hears someone say \"Hey, Vocable\""
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Navegue automáticamente a la categoría Modo de escucha cuando Vocable escuche a alguien decir \"Hey, Vocable\""
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navegue automáticamente a la categoría Modo de escucha cuando Vocable escuche a alguien decir \"Hey, Vocable\""
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accédez automatiquement à la catégorie Mode d'écoute lorsque Vocable entend quelqu'un dire \"Hey, Vocable\""
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accédez automatiquement à la catégorie Mode d'écoute lorsque Vocable entend quelqu'un dire \"Hey, Vocable\""
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "जब वोकेबल किसी को \"अरे, वोकेबल\" कहते हुए सुनता है तो स्वचालित रूप से श्रवण मोड श्रेणी पर नेविगेट करें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जब वोकेबल किसी को \"अरे, वोकेबल\" कहते हुए सुनता है तो स्वचालित रूप से श्रवण मोड श्रेणी पर नेविगेट करें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passa automaticamente alla categoria Modalità di ascolto quando Vocable sente qualcuno dire \"Hey, Vocable\""
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passa automaticamente alla categoria Modalità di ascolto quando Vocable sente qualcuno dire \"Hey, Vocable\""
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vocable이 누군가 \"Hey, Vocable\"이라고 말하는 것을 들으면 자동으로 청취 모드 카테고리로 이동합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vocable이 누군가 \"Hey, Vocable\"이라고 말하는 것을 들으면 자동으로 청취 모드 카테고리로 이동합니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматически переходить в категорию «Режим прослушивания», когда Vocable слышит, как кто-то говорит «Эй, Vocable»"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически переходить в категорию «Режим прослушивания», когда Vocable слышит, как кто-то говорит «Эй, Vocable»"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự động điều hướng đến danh mục Chế độ nghe khi Vocable nghe thấy ai đó nói \"Hey, Vocable\""
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động điều hướng đến danh mục Chế độ nghe khi Vocable nghe thấy ai đó nói \"Hey, Vocable\""
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动导航到侦听模式类别，当有人听到有人说\"嘿，词汇\""
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动导航到侦听模式类别，当有人听到有人说\"嘿，词汇\""
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "當 Vocable 聽到有人說「嘿，Vocable」時自動導航到聆聽模式類別"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "當 Vocable 聽到有人說「嘿，Vocable」時自動導航到聆聽模式類別"
           }
         }
       }
     },
-    "settings.listening_mode.listening_mode_explanation_footer" : {
-      "comment" : "Footer text displayed in the Listening Mode preferences screen. This text describes the overall Listening Mode feature as well as the kinds of responses it can generate for the user.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذه فئة محادثة تستمع إلى شخص ما ليطرح الأسئلة، ثم تقدم مجموعة مختارة من الإجابات. إما/أو الأسئلة والأسئلة التي يمكن الإجابة عليها بنعم أو لا أو برقم مدعومة حاليًا."
+    "settings.listening_mode.listening_mode_explanation_footer": {
+      "comment": "Footer text displayed in the Listening Mode preferences screen. This text describes the overall Listening Mode feature as well as the kinds of responses it can generate for the user.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذه فئة محادثة تستمع إلى شخص ما ليطرح الأسئلة، ثم تقدم مجموعة مختارة من الإجابات. إما/أو الأسئلة والأسئلة التي يمكن الإجابة عليها بنعم أو لا أو برقم مدعومة حاليًا."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dette er en samtalekategori, der lytter til nogen at stille spørgsmål, og tilbyder derefter et udvalg af svar. Either/eller spørgsmål og spørgsmål, der kan besvares med ja, nej, eller et nummer understøttes i øjeblikket."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dette er en samtalekategori, der lytter til nogen at stille spørgsmål, og tilbyder derefter et udvalg af svar. Either/eller spørgsmål og spørgsmål, der kan besvares med ja, nej, eller et nummer understøttes i øjeblikket."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dies ist eine Konversationskategorie, die darauf wartet, dass jemand Fragen stellt, und dann eine Auswahl an Antworten anbietet. Derzeit werden Entweder-Oder-Fragen und Fragen, die mit Ja, Nein oder einer Zahl beantwortet werden können, unterstützt."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dies ist eine Konversationskategorie, die darauf wartet, dass jemand Fragen stellt, und dann eine Auswahl an Antworten anbietet. Derzeit werden Entweder-Oder-Fragen und Fragen, die mit Ja, Nein oder einer Zahl beantwortet werden können, unterstützt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This is a conversational category that listens for someone to ask questions, then offers a selection of responses. Either/or questions and questions that can be answered with yes, no, or a number are currently supported."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a conversational category that listens for someone to ask questions, then offers a selection of responses. Either/or questions and questions that can be answered with yes, no, or a number are currently supported."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta es una categoría conversacional que escucha las preguntas de alguien y luego ofrece una selección de respuestas. Actualmente se admiten preguntas o preguntas que se pueden responder con sí, no o un número."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta es una categoría conversacional que escucha las preguntas de alguien y luego ofrece una selección de respuestas. Actualmente se admiten preguntas o preguntas que se pueden responder con sí, no o un número."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il s'agit d'une catégorie conversationnelle qui écoute quelqu'un poser des questions, puis propose une sélection de réponses. Les questions soit/ou et les questions auxquelles il est possible de répondre par oui, non ou par un nombre sont actuellement prises en charge."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il s'agit d'une catégorie conversationnelle qui écoute quelqu'un poser des questions, puis propose une sélection de réponses. Les questions soit/ou et les questions auxquelles il est possible de répondre par oui, non ou par un nombre sont actuellement prises en charge."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह एक वार्तालाप श्रेणी है जो किसी के प्रश्न पूछने को सुनती है, फिर चुनिंदा प्रतिक्रियाओं की पेशकश करती है। या तो/या ऐसे प्रश्न और प्रश्न जिनका उत्तर हाँ, नहीं या एक संख्या में दिया जा सकता है, वर्तमान में समर्थित हैं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह एक वार्तालाप श्रेणी है जो किसी के प्रश्न पूछने को सुनती है, फिर चुनिंदा प्रतिक्रियाओं की पेशकश करती है। या तो/या ऐसे प्रश्न और प्रश्न जिनका उत्तर हाँ, नहीं या एक संख्या में दिया जा सकता है, वर्तमान में समर्थित हैं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questa è una categoria conversazionale che ascolta qualcuno che pone domande, quindi offre una selezione di risposte. Attualmente sono supportate sia/o domande e domande a cui è possibile rispondere con sì, no o con un numero."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa è una categoria conversazionale che ascolta qualcuno che pone domande, quindi offre una selezione di risposte. Attualmente sono supportate sia/o domande e domande a cui è possibile rispondere con sì, no o con un numero."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이것은 누군가가 질문하는 것을 듣고 선택적인 응답을 제공하는 대화 카테고리입니다. 현재는 예, 아니오 또는 숫자로 대답할 수 있는 질문과 질문이 지원됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이것은 누군가가 질문하는 것을 듣고 선택적인 응답을 제공하는 대화 카테고리입니다. 현재는 예, 아니오 또는 숫자로 대답할 수 있는 질문과 질문이 지원됩니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Это разговорная категория, которая слушает, когда кто-то задает вопросы, а затем предлагает выбор ответов. В настоящее время поддерживаются вопросы «или/или», а также вопросы, на которые можно ответить «да», «нет» или число."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это разговорная категория, которая слушает, когда кто-то задает вопросы, а затем предлагает выбор ответов. В настоящее время поддерживаются вопросы «или/или», а также вопросы, на которые можно ответить «да», «нет» или число."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đây là thể loại đàm thoại lắng nghe người khác đặt câu hỏi, sau đó đưa ra các câu trả lời chọn lọc. Hiện tại, các câu hỏi và câu hỏi có thể được trả lời bằng có, không hoặc một số đều được hỗ trợ."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đây là thể loại đàm thoại lắng nghe người khác đặt câu hỏi, sau đó đưa ra các câu trả lời chọn lọc. Hiện tại, các câu hỏi và câu hỏi có thể được trả lời bằng có, không hoặc một số đều được hỗ trợ."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这是一个对话类别，听取某人提问，然后提供一系列答复。 目前支持可用回答、否或数字回答的问题和问题。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这是一个对话类别，听取某人提问，然后提供一系列答复。 目前支持可用回答、否或数字回答的问题和问题。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這是一個對話類別，聆聽某人提出問題，然後提供一系列答案。 目前支援非此即彼的問題以及可以用是、否或數字回答的問題。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這是一個對話類別，聆聽某人提出問題，然後提供一系列答案。 目前支援非此即彼的問題以及可以用是、否或數字回答的問題。"
           }
         }
       }
     },
-    "settings.listening_mode.listening_mode_toggle_cell.title" : {
-      "comment" : "Title of Listening Mode preferences cell that toggles Listening Mode on or off when selected",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع الاستماع"
+    "settings.listening_mode.listening_mode_toggle_cell.title": {
+      "comment": "Title of Listening Mode preferences cell that toggles Listening Mode on or off when selected",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع الاستماع"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyttefunktion"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyttefunktion"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hörmodus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de escucha"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de escucha"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode d'écoute"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode d'écoute"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सुनने का तरीका"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनने का तरीका"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità di ascolto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità di ascolto"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "듣기 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "듣기 모드"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим прослушивания"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим прослушивания"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ nghe"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ nghe"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在侦听模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在侦听模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聆聽模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聆聽模式"
           }
         }
       }
     },
-    "settings.listening_mode.smart_assist_explanation_footer" : {
-      "comment" : "Footer text displayed in the Listening Mode preferences screen. This text describes the Smart Assist feature and how it works.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يستخدم Smart Assist الذكاء الاصطناعي لتقديم اقتراحات ذات جودة أعلى لوضع الاستماع. يلزم الاتصال بالإنترنت، ولكن لا يتم تخزين سجل المحادثات على الإطلاق، تمامًا كما هو الحال في وضع الاستماع العادي."
+    "settings.listening_mode.smart_assist_explanation_footer": {
+      "comment": "Footer text displayed in the Listening Mode preferences screen. This text describes the Smart Assist feature and how it works.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يستخدم Smart Assist الذكاء الاصطناعي لتقديم اقتراحات ذات جودة أعلى لوضع الاستماع. يلزم الاتصال بالإنترنت، ولكن لا يتم تخزين سجل المحادثات على الإطلاق، تمامًا كما هو الحال في وضع الاستماع العادي."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist bruger AI til at levere forslag af højere kvalitet til lyttetilstand. En internetforbindelse er påkrævet, men ingen samtale historie nogensinde er gemt, ligesom i regelmæssig lytning tilstand."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist bruger AI til at levere forslag af højere kvalitet til lyttetilstand. En internetforbindelse er påkrævet, men ingen samtale historie nogensinde er gemt, ligesom i regelmæssig lytning tilstand."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist verwendet die KI um qualitativ hochwertigere Vorschläge für den Hörmodus bereitzustellen. Eine Internetverbindung ist erforderlich, aber es wird nie ein Gesprächsverlauf gespeichert, genau wie im regulären Hörmodus."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist verwendet die KI um qualitativ hochwertigere Vorschläge für den Hörmodus bereitzustellen. Eine Internetverbindung ist erforderlich, aber es wird nie ein Gesprächsverlauf gespeichert, genau wie im regulären Hörmodus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist uses AI to provide higher-quality suggestions for Listening Mode. An Internet connection is required, but no conversation history is ever stored, just like in regular Listening Mode."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist uses AI to provide higher-quality suggestions for Listening Mode. An Internet connection is required, but no conversation history is ever stored, just like in regular Listening Mode."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist utiliza IA para brindar sugerencias de mayor calidad para el modo de escucha. Se requiere una conexión a Internet, pero nunca se almacena el historial de conversaciones, como en el modo de escucha normal."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist utiliza IA para brindar sugerencias de mayor calidad para el modo de escucha. Se requiere una conexión a Internet, pero nunca se almacena el historial de conversaciones, como en el modo de escucha normal."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist utilise l'IA pour fournir des suggestions de meilleure qualité pour le mode d'écoute. Une connexion Internet est requise, mais aucun historique de conversation n'est jamais stocké, tout comme en mode d'écoute normal."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist utilise l'IA pour fournir des suggestions de meilleure qualité pour le mode d'écoute. Une connexion Internet est requise, mais aucun historique de conversation n'est jamais stocké, tout comme en mode d'écoute normal."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "स्मार्ट असिस्ट लिसनिंग मोड के लिए उच्च गुणवत्ता वाले सुझाव प्रदान करने के लिए एआई का उपयोग करता है। एक इंटरनेट कनेक्शन की आवश्यकता है, लेकिन नियमित श्रवण मोड की तरह, कोई भी वार्तालाप इतिहास कभी भी संग्रहीत नहीं किया जाता है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्मार्ट असिस्ट लिसनिंग मोड के लिए उच्च गुणवत्ता वाले सुझाव प्रदान करने के लिए एआई का उपयोग करता है। एक इंटरनेट कनेक्शन की आवश्यकता है, लेकिन नियमित श्रवण मोड की तरह, कोई भी वार्तालाप इतिहास कभी भी संग्रहीत नहीं किया जाता है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist utilizza l'intelligenza artificiale per fornire suggerimenti di qualità superiore per la modalità di ascolto. È necessaria una connessione Internet, ma non viene mai memorizzata la cronologia delle conversazioni, proprio come nella normale modalità di ascolto."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist utilizza l'intelligenza artificiale per fornire suggerimenti di qualità superiore per la modalità di ascolto. È necessaria una connessione Internet, ma non viene mai memorizzata la cronologia delle conversazioni, proprio come nella normale modalità di ascolto."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist는 AI를 사용하여 청취 모드에 대한 고품질 제안을 제공합니다. 인터넷 연결이 필요하지만 일반 듣기 모드와 마찬가지로 대화 기록은 저장되지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist는 AI를 사용하여 청취 모드에 대한 고품질 제안을 제공합니다. 인터넷 연결이 필요하지만 일반 듣기 모드와 마찬가지로 대화 기록은 저장되지 않습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist использует искусственный интеллект для предоставления более качественных предложений для режима прослушивания. Требуется подключение к Интернету, но история разговоров не сохраняется, как и в обычном режиме прослушивания."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist использует искусственный интеллект для предоставления более качественных предложений для режима прослушивания. Требуется подключение к Интернету, но история разговоров не сохраняется, как и в обычном режиме прослушивания."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hỗ trợ thông minh sử dụng AI để đưa ra đề xuất chất lượng cao hơn cho Chế độ nghe. Cần có kết nối Internet nhưng không có lịch sử hội thoại nào được lưu trữ, giống như ở Chế độ Nghe thông thường."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hỗ trợ thông minh sử dụng AI để đưa ra đề xuất chất lượng cao hơn cho Chế độ nghe. Cần có kết nối Internet nhưng không có lịch sử hội thoại nào được lưu trữ, giống như ở Chế độ Nghe thông thường."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "智能助手使用 AI 提供更高质量的侦听模式建议。 需要互联网连接，但是不会像常规侦听模式一样存储任何对话历史。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能助手使用 AI 提供更高质量的侦听模式建议。 需要互联网连接，但是不会像常规侦听模式一样存储任何对话历史。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "智慧輔助使用人工智慧為聆聽模式提供更高品質的建議。 需要網路連接，但不會儲存任何對話歷史記錄，就像常規聆聽模式一樣。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智慧輔助使用人工智慧為聆聽模式提供更高品質的建議。 需要網路連接，但不會儲存任何對話歷史記錄，就像常規聆聽模式一樣。"
           }
         }
       }
     },
-    "settings.listening_mode.smart_assist_toggle_cell.title" : {
-      "comment" : "Title of Smart Assist preferences cell that toggles the Smart Assist feature on or off when selected",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "المساعدة الذكية"
+    "settings.listening_mode.smart_assist_toggle_cell.title": {
+      "comment": "Title of Smart Assist preferences cell that toggles the Smart Assist feature on or off when selected",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المساعدة الذكية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intelligenter Assistent"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intelligenter Assistent"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Smart Assist"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart Assist"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asistente Inteligente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asistente Inteligente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assistance intelligente"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistance intelligente"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "स्मार्ट सहायता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्मार्ट सहायता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assistenza intelligente"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assistenza intelligente"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "스마트 어시스트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스마트 어시스트"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Умный помощник"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Умный помощник"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trợ lý thông minh"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trợ lý thông minh"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "智能助手"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能助手"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "智慧輔助"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智慧輔助"
           }
         }
       }
     },
-    "settings.listening_mode.title" : {
-      "comment" : "Listening Mode preferences screen title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع الاستماع"
+    "settings.listening_mode.title": {
+      "comment": "Listening Mode preferences screen title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع الاستماع"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lyttefunktion"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lyttefunktion"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hörmodus"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörmodus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Listening Mode"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listening Mode"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo de escucha"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo de escucha"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mode d'écoute"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode d'écoute"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "सुनने का तरीका"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनने का तरीका"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modalità di ascolto"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità di ascolto"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "듣기 모드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "듣기 모드"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим прослушивания"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим прослушивания"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ nghe"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chế độ nghe"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在侦听模式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在侦听模式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "聆聽模式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聆聽模式"
           }
         }
       }
     },
-    "settings.selection_mode.head_tracking_unsupported_footer" : {
-      "comment" : "Additonal footer text noting heading tracking compatibility",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "هذا %1$@ على %2$@ %3$@ لا يدعم تتبع الرأس.\n\nتتبع الرأس مدعوم على جميع الأجهزة مع كاميرا %4$@ ، وعلى معظم الأجهزة باستخدام %5$@."
+    "settings.selection_mode.head_tracking_unsupported_footer": {
+      "comment": "Additonal footer text noting heading tracking compatibility",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هذا %1$@ على %2$@ %3$@ لا يدعم تتبع الرأس.\n\nتتبع الرأس مدعوم على جميع الأجهزة مع كاميرا %4$@ ، وعلى معظم الأجهزة باستخدام %5$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Denne %1$@ på %2$@ %3$@ understøtter ikke hovedsporing.\n\nHovedsporing understøttes på alle enheder med et %4$@ kamera og på de fleste enheder med %5$@."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denne %1$@ på %2$@ %3$@ understøtter ikke hovedsporing.\n\nHovedsporing understøttes på alle enheder med et %4$@ kamera og på de fleste enheder med %5$@."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses %1$@ auf %2$@ %3$@ unterstützt keine Head-Tracking.\n\nHead-Tracking wird auf allen Geräten mit einer %4$@ Kamera und auf den meisten Geräten mit %5$@ unterstützt."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses %1$@ auf %2$@ %3$@ unterstützt keine Head-Tracking.\n\nHead-Tracking wird auf allen Geräten mit einer %4$@ Kamera und auf den meisten Geräten mit %5$@ unterstützt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This %1$@ on %2$@ %3$@ does not support head tracking.\n\nHead tracking is supported on all devices with a %4$@ camera, and on most devices with %5$@."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This %1$@ on %2$@ %3$@ does not support head tracking.\n\nHead tracking is supported on all devices with a %4$@ camera, and on most devices with %5$@."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este %1$@ con %2$@ %3$@ no admite el seguimiento de la cabeza.\n\nEl seguimiento de la cabeza es compatible con todos los dispositivos con una cámara %4$@ y en la mayoría de los dispositivos con %5$@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este %1$@ con %2$@ %3$@ no admite el seguimiento de la cabeza.\n\nEl seguimiento de la cabeza es compatible con todos los dispositivos con una cámara %4$@ y en la mayoría de los dispositivos con %5$@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le suivi de la tête.\n\nLe suivi de la tête est pris en charge sur tous les appareils équipés d'une caméra %4$@ et sur la plupart des appareils dotés de %5$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce %1$@ sur %2$@ %3$@ ne prend pas en charge le suivi de la tête.\n\nLe suivi de la tête est pris en charge sur tous les appareils équipés d'une caméra %4$@ et sur la plupart des appareils dotés de %5$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यह %1$@ %2$@ %3$@ पर हेड ट्रैकिंग का समर्थन नहीं करता है।\n\nहेड ट्रैकिंग %4$@ कैमरे वाले सभी डिवाइसों पर और %5$@ वाले अधिकांश डिवाइसों पर समर्थित है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह %1$@ %2$@ %3$@ पर हेड ट्रैकिंग का समर्थन नहीं करता है।\n\nहेड ट्रैकिंग %4$@ कैमरे वाले सभी डिवाइसों पर और %5$@ वाले अधिकांश डिवाइसों पर समर्थित है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo %1$@ su %2$@ %3$@ non supporta il head tracking.\n\nIl tracking testa è supportato su tutti i dispositivi con una fotocamera %4$@ e sulla maggior parte dei dispositivi con %5$@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo %1$@ su %2$@ %3$@ non supporta il head tracking.\n\nIl tracking testa è supportato su tutti i dispositivi con una fotocamera %4$@ e sulla maggior parte dei dispositivi con %5$@."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 %1$@ on %2$@ %3$@는 헤드 추적을 지원하지 않습니다.\n\n헤드 추적은 %4$@ 카메라가있는 모든 장치와 %5$@ 의 대부분의 장치에서 지원됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 %1$@ on %2$@ %3$@는 헤드 추적을 지원하지 않습니다.\n\n헤드 추적은 %4$@ 카메라가있는 모든 장치와 %5$@ 의 대부분의 장치에서 지원됩니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этот %1$@ на %2$@ %3$@ не поддерживает отслеживание головы.\n\nОтслеживание Head поддерживается на всех устройствах с помощью %4$@ камеры, а также на большинстве устройств с помощью %5$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот %1$@ на %2$@ %3$@ не поддерживает отслеживание головы.\n\nОтслеживание Head поддерживается на всех устройствах с помощью %4$@ камеры, а также на большинстве устройств с помощью %5$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ này trên %2$@ %3$@ này không hỗ trợ theo dõi đầu.\n\nTheo dõi đầu được hỗ trợ trên tất cả các thiết bị có camera %4$@ và trên hầu hết các thiết bị có %5$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ này trên %2$@ %3$@ này không hỗ trợ theo dõi đầu.\n\nTheo dõi đầu được hỗ trợ trên tất cả các thiết bị có camera %4$@ và trên hầu hết các thiết bị có %5$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此 %1$@ 在 %2$@ %3$@ 不支持头条跟踪。\n\n在所有带有 %4$@ 相机的设备以及大多数带有 %5$@的设备上支持头部跟踪。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此 %1$@ 在 %2$@ %3$@ 不支持头条跟踪。\n\n在所有带有 %4$@ 相机的设备以及大多数带有 %5$@的设备上支持头部跟踪。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@ %3$@ 上的此 %1$@ 不支援頭部追蹤。\n\n所有配備 %4$@ 攝影機的設備以及大多數配備 %5$@ 的設備均支援頭部追蹤。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ %3$@ 上的此 %1$@ 不支援頭部追蹤。\n\n所有配備 %4$@ 攝影機的設備以及大多數配備 %5$@ 的設備均支援頭部追蹤。"
           }
         }
       }
     },
-    "settings.version_format" : {
-      "comment" : "Version information displayed at the bottom of the Settings screen. Argument is the application version.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الإصدار %1$@"
+    "settings.version_format": {
+      "comment": "Version information displayed at the bottom of the Settings screen. Argument is the application version.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإصدار %1$@"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión %1$@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %1$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %1$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %1$@"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "संस्करण %1$@"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संस्करण %1$@"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versione %1$@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione %1$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버전 %1$@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버전 %1$@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия %1$@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %1$@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản %1$@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản %1$@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本 %1$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本 %1$@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本%1$@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本%1$@"
           }
         }
       }
     },
-    "text_editor.alert.cancel_editing_confirmation.button.continue_editing.title" : {
-      "comment" : "Button in the edit category title close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will allow editing the category title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الاستمرار في التعديل"
+    "text_editor.alert.cancel_editing_confirmation.button.continue_editing.title": {
+      "comment": "Button in the edit category title close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will allow editing the category title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستمرار في التعديل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortsæt Redigering"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortsæt Redigering"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter editieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter editieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue Editing"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue Editing"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar Edición"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar Edición"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer l'édition"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer l'édition"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "संपादन जारी रखें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संपादन जारी रखें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continua la modifica"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua la modifica"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계속 편집"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속 편집"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить редактирование"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить редактирование"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếp tục chỉnh sửa"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục chỉnh sửa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续编辑"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续编辑"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繼續編輯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續編輯"
           }
         }
       }
     },
-    "text_editor.alert.cancel_editing_confirmation.button.discard.title" : {
-      "comment" : "Button in the edit category title close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will not save any changes and close the keyboard view.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تجاهل"
+    "text_editor.alert.cancel_editing_confirmation.button.discard.title": {
+      "comment": "Button in the edit category title close confirmation. This button appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes. Pressing the button will not save any changes and close the keyboard view.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تجاهل"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slet"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slet"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwerfen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwerfen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Discard"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discard"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descartar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descartar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeter"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "छोड़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "छोड़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scartare"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scartare"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버리다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버리다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отказаться"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отказаться"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ đi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ đi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "舍弃"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "舍弃"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "丟棄"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "丟棄"
           }
         }
       }
     },
-    "text_editor.alert.cancel_editing_confirmation.title" : {
-      "comment" : "Category close confirmation text.  This text appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إذا أغلقت بدون حفظ ، فستفقد التغييرات."
+    "text_editor.alert.cancel_editing_confirmation.title": {
+      "comment": "Category close confirmation text.  This text appears in an alert when there are edits made to the Category title and the user tries to close the keyboard without saving the changes.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إذا أغلقت بدون حفظ ، فستفقد التغييرات."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hvis du lukker uden at gemme, vil dine ændringer gå tabt."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hvis du lukker uden at gemme, vil dine ændringer gå tabt."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie ohne Speichern schließen, gehen Ihre Änderungen verloren."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie ohne Speichern schließen, gehen Ihre Änderungen verloren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you close without saving, your changes will be lost."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you close without saving, your changes will be lost."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si cierra sin guardar, sus cambios se perderán."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si cierra sin guardar, sus cambios se perderán."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si vous fermez sans enregistrer, vos modifications seront perdues."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si vous fermez sans enregistrer, vos modifications seront perdues."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "यदि आप सहेजे बिना बंद कर देते हैं, तो आपके परिवर्तन खो जाएंगे।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यदि आप सहेजे बिना बंद कर देते हैं, तो आपके परिवर्तन खो जाएंगे।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se si chiude senza salvare, le modifiche andranno perse."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se si chiude senza salvare, le modifiche andranno perse."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "저장하지 않고 닫으면 변경 사항이 손실됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장하지 않고 닫으면 변경 사항이 손실됩니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Если вы закроете без сохранения, ваши изменения будут потеряны."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если вы закроете без сохранения, ваши изменения будут потеряны."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nếu bạn đóng mà không lưu, các thay đổi của bạn sẽ bị mất."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nếu bạn đóng mà không lưu, các thay đổi của bạn sẽ bị mất."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您关闭而不保存，您的更改将丢失。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您关闭而不保存，您的更改将丢失。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您關閉而不保存，您的更改將會丟失。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您關閉而不保存，您的更改將會丟失。"
           }
         }
       }
     },
-    "text_editor.alert.category_name_exists.cancel.button" : {
-      "comment" : "Duplicate Category alert cancel button.  Text on this button appears on an alert where a duplicate category title is being created.\n   Pressing the button will allow continuing to edit category title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "يلغي"
+    "text_editor.alert.category_name_exists.cancel.button": {
+      "comment": "Duplicate Category alert cancel button.  Text on this button appears on an alert where a duplicate category title is being created.\n   Pressing the button will allow continuing to edit category title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يلغي"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuller"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuller"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "रद्द करना"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करना"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annulla"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "취소"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отмена"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hủy bỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy bỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
           }
         }
       }
     },
-    "text_editor.alert.category_name_exists.create.button" : {
-      "comment" : "Duplicate Alert create duplicate button.  Pressing this button will allow for multiple categories with the same title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إنشاء نسخة مكررة"
+    "text_editor.alert.category_name_exists.create.button": {
+      "comment": "Duplicate Alert create duplicate button.  Pressing this button will allow for multiple categories with the same title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء نسخة مكررة"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opret dublet"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opret dublet"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duplizieren"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplizieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Duplicate"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Duplicate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crear duplicado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear duplicado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer un doublon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer un doublon"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "डुप्लिकेट बनाएं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डुप्लिकेट बनाएं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Crea duplicato"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea duplicato"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중복 생성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중복 생성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создать дубликат"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать дубликат"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tạo bản sao"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo bản sao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建副本"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建副本"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "創建副本"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創建副本"
           }
         }
       }
     },
-    "text_editor.alert.category_name_exists.title" : {
-      "comment" : "Duplicate Category alert text.  This text appears in an alert when a category is created with the same title as an existing category.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اسم الفئة هذا موجود بالفعل. هل ترغب في إنشاء نسخة مكررة؟"
+    "text_editor.alert.category_name_exists.title": {
+      "comment": "Duplicate Category alert text.  This text appears in an alert when a category is created with the same title as an existing category.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم الفئة هذا موجود بالفعل. هل ترغب في إنشاء نسخة مكررة؟"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dette kategorinavn findes allerede. Vil du oprette et duplikat?"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dette kategorinavn findes allerede. Vil du oprette et duplikat?"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Kategorie gibt es bereits. Möchten Sie sie duplizieren?"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Kategorie gibt es bereits. Möchten Sie sie duplizieren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This category name already exists. Would you like to create a duplicate?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This category name already exists. Would you like to create a duplicate?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El nombre de esta categoría ya existe. ¿Desea crear un duplicado?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El nombre de esta categoría ya existe. ¿Desea crear un duplicado?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce nom de catégorie existe déjà. Souhaitez-vous créer un doublon ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce nom de catégorie existe déjà. Souhaitez-vous créer un doublon ?"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इस श्रेणी का नाम पहले से मौजूद है। क्या आप डुप्लीकेट बनाना चाहेंगे?"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस श्रेणी का नाम पहले से मौजूद है। क्या आप डुप्लीकेट बनाना चाहेंगे?"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Questo nome di categoria esiste già. Vuoi creare un duplicato?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo nome di categoria esiste già. Vuoi creare un duplicato?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 카테고리 이름은 이미 존재합니다. 복제본을 생성하시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 카테고리 이름은 이미 존재합니다. 복제본을 생성하시겠습니까?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Это название категории уже существует. Хотите создать дубликат?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это название категории уже существует. Хотите создать дубликат?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tên thể loại này đã tồn tại. Bạn có muốn tạo một bản sao không?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên thể loại này đã tồn tại. Bạn có muốn tạo một bản sao không?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此类别名称已存在。您想创建一个副本吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此类别名称已存在。您想创建一个副本吗？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此類別名稱已存在。您想創建一個副本嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此類別名稱已存在。您想創建一個副本嗎？"
           }
         }
       }
     },
-    "timing_and_sensitivity.button.high.title" : {
-      "comment" : "Button option for the Curson Sensitivity setting.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مرتفع"
+    "timing_and_sensitivity.button.high.title": {
+      "comment": "Button option for the Curson Sensitivity setting.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرتفع"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Høj"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Høj"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoch"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoch"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "High"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alta"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Élevée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Élevée"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "उच्च"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "उच्च"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alta"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alta"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "높은"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "높은"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Высокая"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Высокая"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cao"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "高"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
           }
         }
       }
     },
-    "timing_and_sensitivity.button.low.title" : {
-      "comment" : "Button option for the Curson Sensitivity setting.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "أدنى"
+    "timing_and_sensitivity.button.low.title": {
+      "comment": "Button option for the Curson Sensitivity setting.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أدنى"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lav"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lav"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niedrig"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niedrig"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Low"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baja"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baja"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Faible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faible"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कम"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कम"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basso"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basso"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "낮음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "낮음"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Низкий"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Низкий"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thấp"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thấp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "低"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
           }
         }
       }
     },
-    "timing_and_sensitivity.button.medium.title" : {
-      "comment" : "Button option for the Curson Sensitivity setting.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "متوسط"
+    "timing_and_sensitivity.button.medium.title": {
+      "comment": "Button option for the Curson Sensitivity setting.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوسط"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mellem"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mellem"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mittel"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medium"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Media"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moyen"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moyen"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "मध्यम"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मध्यम"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Media"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중간 서체"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중간 서체"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Середина"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Середина"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vừa phải"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vừa phải"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中等"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中等"
           }
         }
       }
     },
-    "timing_and_sensitivity.cell.cursor_sensitivity.title" : {
-      "comment" : "Text for a Timing and sensitivity setting.  This setting is the sensitivity for the head tracking cursor.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حساسية المؤشر"
+    "timing_and_sensitivity.cell.cursor_sensitivity.title": {
+      "comment": "Text for a Timing and sensitivity setting.  This setting is the sensitivity for the head tracking cursor.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حساسية المؤشر"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Markørfølsomhed"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markørfølsomhed"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeigerempfindlichkeit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigerempfindlichkeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cursor Sensitivity"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursor Sensitivity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensibilidad del cursor"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sensibilidad del cursor"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensibilité du curseur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sensibilité du curseur"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कर्सर संवेदनशीलता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर संवेदनशीलता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sensibilità del cursore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sensibilità del cursore"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커서 감도"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커서 감도"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чувствительность курсора"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чувствительность курсора"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Độ nhạy con trỏ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Độ nhạy con trỏ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "指针敏度"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指针敏度"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "光標靈敏度"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "光標靈敏度"
           }
         }
       }
     },
-    "timing_and_sensitivity.cell.dwell_duration.title" : {
-      "comment" : "Text for a Timing and sensitivity setting.  This setting is the amount of time the head tracking cursor needs to stay on a button before it triggers it.\n   Hove time can be adjusted in .5 sec increments from .5 to 5",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الوقت تحوم"
+    "timing_and_sensitivity.cell.dwell_duration.title": {
+      "comment": "Text for a Timing and sensitivity setting.  This setting is the amount of time the head tracking cursor needs to stay on a button before it triggers it.\n   Hove time can be adjusted in .5 sec increments from .5 to 5",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوقت تحوم"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pegetid"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegetid"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schwebezeit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwebezeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hover Time"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hover Time"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hover Tme"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hover Tme"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temps de survol"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temps de survol"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "होवर टाइम"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "होवर टाइम"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hover Time"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hover Time"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "호버 타임"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "호버 타임"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Время наведения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время наведения"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thời gian di chuột"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thời gian di chuột"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "徘徊时间"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "徘徊时间"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "懸停時間"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "懸停時間"
           }
         }
       }
     },
-    "timing_and_sensitivity.header.title" : {
-      "comment" : "Timing and sensitivity Header title.  This text appears in the Settings flow when navigating into the Timing and Sensitivity setting",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التوقيت و الحساسية"
+    "timing_and_sensitivity.header.title": {
+      "comment": "Timing and sensitivity Header title.  This text appears in the Settings flow when navigating into the Timing and Sensitivity setting",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التوقيت و الحساسية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing og Følsomhed"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing og Følsomhed"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing und Empfindlichkeit"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing und Empfindlichkeit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing and Sensitivity"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing and Sensitivity"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiempo y sensibilidad"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiempo y sensibilidad"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timing et Sensibilité"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timing et Sensibilité"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "समय और संवेदनशीलता"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समय और संवेदनशीलता"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempistiche e sensibilità"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tempistiche e sensibilità"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "타이밍과 감도"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타이밍과 감도"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Время и чувствительность"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время и чувствительность"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thời gian và độ nhạy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thời gian và độ nhạy"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "时间和灵敏度"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时间和灵敏度"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "時間和靈敏度"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時間和靈敏度"
           }
         }
       }
     },
-    "voice_picker.empty_state.description" : {
-      "comment" : "Voice picker empty state body. Shown when the user attempts to change their voice settings and the operating system\nfails to return any viable voice profiles that the user could select from.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لم يتم تثبيت أي أصوات تطابق إعدادات اللغة والمنطقة الخاصة بك."
+    "voice_picker.empty_state.description": {
+      "comment": "Voice picker empty state body. Shown when the user attempts to change their voice settings and the operating system\nfails to return any viable voice profiles that the user could select from.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم تثبيت أي أصوات تطابق إعدادات اللغة والمنطقة الخاصة بك."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen stemmer, der matcher dine sprog- og regionsindstillinger, er installeret."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen stemmer, der matcher dine sprog- og regionsindstillinger, er installeret."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es sind keine Stimmen installiert, die Ihren Sprach- und Regionseinstellungen entsprechen."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es sind keine Stimmen installiert, die Ihren Sprach- und Regionseinstellungen entsprechen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No voices that match your language and region settings are installed."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No voices that match your language and region settings are installed."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se instalan voces que coincidan con la configuración de idioma y región."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se instalan voces que coincidan con la configuración de idioma y región."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune voix correspondant à vos paramètres de langue et de région n'est installée."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune voix correspondant à vos paramètres de langue et de région n'est installée."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आपकी भाषा और क्षेत्र सेटिंग से मेल खाने वाली कोई भी आवाज़ इंस्टॉल नहीं की गई है।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी भाषा और क्षेत्र सेटिंग से मेल खाने वाली कोई भी आवाज़ इंस्टॉल नहीं की गई है।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non sono installate voci che corrispondono alle impostazioni della lingua e della regione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non sono installate voci che corrispondono alle impostazioni della lingua e della regione."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어 및 지역 설정과 일치하는 음성이 설치되어 있지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어 및 지역 설정과 일치하는 음성이 설치되어 있지 않습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Голоса, соответствующие настройкам вашего языка и региона, не установлены."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Голоса, соответствующие настройкам вашего языка и региона, не установлены."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có giọng nói nào phù hợp với cài đặt ngôn ngữ và khu vực của bạn được cài đặt."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có giọng nói nào phù hợp với cài đặt ngôn ngữ và khu vực của bạn được cài đặt."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有安装与您的语言和区域设置匹配的声音。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有安装与您的语言和区域设置匹配的声音。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未安裝與您的語言和區域設定相符的語音。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安裝與您的語言和區域設定相符的語音。"
           }
         }
       }
     },
-    "voice_picker.empty_state.title" : {
-      "comment" : "Voice picker empty state title.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا أصوات"
+    "voice_picker.empty_state.title": {
+      "comment": "Voice picker empty state title.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا أصوات"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen Stemmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen Stemmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Stimmen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Stimmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Voices"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Voices"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin Voces"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin Voces"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas de voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas de voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "कोई आवाज़ नहीं"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कोई आवाज़ नहीं"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna Voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna Voce"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 없음"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 없음"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет голосов"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет голосов"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có tiếng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có tiếng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有聲音"
           }
         }
       }
     },
-    "voice_picker.title" : {
-      "comment" : "Voice Picker title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تغيير الصوت"
+    "voice_picker.title": {
+      "comment": "Voice Picker title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تغيير الصوت"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skift Stemme"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skift Stemme"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimme ändern"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme ändern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change Voice"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Voice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar Voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar Voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changer de Voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de Voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज बदलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज बदलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia Voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia Voce"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 변경"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 변경"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменить голос"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить голос"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thay đổi giọng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thay đổi giọng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "改變聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改變聲音"
           }
         }
       }
     },
-    "voice_preview.sample_audio.introducion_format" : {
-      "comment" : "In the voice configuration screen within the app's settings, this format is used to construct the phrase read aloud when the user selects a button to preview a voice profile. Each voice profile has a name provided by the operating system, so the phrase is currently structured as if the voice profile is introducing itself.",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مرحبًا، أنا %1$@"
+    "voice_preview.sample_audio.introducion_format": {
+      "comment": "In the voice configuration screen within the app's settings, this format is used to construct the phrase read aloud when the user selects a button to preview a voice profile. Each voice profile has a name provided by the operating system, so the phrase is currently structured as if the voice profile is introducing itself.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرحبًا، أنا %1$@"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hallo, det er %1$@"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hallo, det er %1$@"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hallo, das ist %1$@"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hallo, das ist %1$@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hello, this is %1$@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hello, this is %1$@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hola, esto es %1$@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hola, esto es %1$@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonjour, ceci est %1$@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonjour, ceci est %1$@"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "नमस्ते, यह %1$@ है"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नमस्ते, यह %1$@ है"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ciao, questo è %1$@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciao, questo è %1$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "안녕하세요 %1$@입니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안녕하세요 %1$@입니다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Привет, это %1$@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Привет, это %1$@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xin chào, đây là %1$@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xin chào, đây là %1$@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您好，这是 %1$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您好，这是 %1$@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您好，我是%1$@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您好，我是%1$@"
           }
         }
       }
     },
-    "voice_settings.cell.change_voice.title" : {
-      "comment" : "Button in the Voice Settings screen that will navigate the user to the voice picker/Change Voice screen",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تغيير الصوت"
+    "voice_settings.cell.change_voice.title": {
+      "comment": "Button in the Voice Settings screen that will navigate the user to the voice picker/Change Voice screen",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تغيير الصوت"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skift Stemme"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skift Stemme"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimme ändern"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme ändern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change Voice"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Voice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar Voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar Voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changer de Voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de Voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज बदलें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज बदलें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia Voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia Voce"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성 변경"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성 변경"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменить голос"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить голос"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thay đổi giọng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thay đổi giọng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "改變聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改變聲音"
           }
         }
       }
     },
-    "voice_settings.cell.personal_voice.title" : {
-      "comment" : "Button in the Voice Settings screen that will navigate the user to the Personal Voice screen",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "الأصوات الشخصية"
+    "voice_settings.cell.personal_voice.title": {
+      "comment": "Button in the Voice Settings screen that will navigate the user to the Personal Voice screen",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأصوات الشخصية"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personlige Stemmer"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personlige Stemmer"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Persönliche Stimmen"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persönliche Stimmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personal Voices"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personal Voices"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voces Personales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voces Personales"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix personnelles"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix personnelles"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "व्यक्तिगत आवाज़ें"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "व्यक्तिगत आवाज़ें"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voci personali"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voci personali"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 음성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개인 음성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Личные голоса"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Личные голоса"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếng nói cá nhân"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng nói cá nhân"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "个人语音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "个人语音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人聲音"
           }
         }
       }
     },
-    "voice_settings.title" : {
-      "comment" : "Voice Configuration title",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "صوت"
+    "voice_settings.title": {
+      "comment": "Voice Configuration title",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صوت"
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stemme"
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stemme"
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimme"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voice"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voz"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voz"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voix"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voix"
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "आवाज़"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आवाज़"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voce"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voce"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "음성"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "음성"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разговор"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разговор"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiếng nói"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng nói"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "嗓音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "嗓音"
           }
         }
       }
     },
-    "voice_settings.voice_picker_footer.title" : {
-      "comment" : "Footer title that accompanies the button that will present the voice picker. This is meant to inform the user that additional voices can be downloaded from the system settings app. The parameter variable is substituted with the device model e.g. \"iPad\" or \"iPhone\".",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "قد تكون الأصوات الإضافية وتحسينات جودة الصوت متاحة للتحميل في إعدادات %1$@."
+    "voice_settings.voice_picker_footer.title": {
+      "comment": "Footer title that accompanies the button that will present the voice picker. This is meant to inform the user that additional voices can be downloaded from the system settings app. The parameter variable is substituted with the device model e.g. \"iPad\" or \"iPhone\".",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قد تكون الأصوات الإضافية وتحسينات جودة الصوت متاحة للتحميل في إعدادات %1$@."
           }
         },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yderligere stemmer og forbedringer af talekvalitet kan være tilgængelige for download i %1$@ indstillinger."
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yderligere stemmer og forbedringer af talekvalitet kan være tilgængelige for download i %1$@ indstillinger."
           }
         },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zusätzliche Stimm- und Sprachqualitätsverbesserungen können in %1$@ Einstellungen heruntergeladen werden."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusätzliche Stimm- und Sprachqualitätsverbesserungen können in %1$@ Einstellungen heruntergeladen werden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Additional voices and voice quality enhancements may be available for download in %1$@ Settings."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Additional voices and voice quality enhancements may be available for download in %1$@ Settings."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es posible que haya voces adicionales y mejoras de calidad de voz disponibles para su descarga en la configuración de %1$@."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es posible que haya voces adicionales y mejoras de calidad de voz disponibles para su descarga en la configuración de %1$@."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Des voix supplémentaires et des améliorations de la qualité de la voix peuvent être téléchargées dans les paramètres %1$@."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Des voix supplémentaires et des améliorations de la qualité de la voix peuvent être téléchargées dans les paramètres %1$@."
           }
         },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "अतिरिक्त आवाजें और आवाज गुणवत्ता संवर्द्धन %1$@ सेटिंग्स में डाउनलोड के लिए उपलब्ध हो सकते हैं।"
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अतिरिक्त आवाजें और आवाज गुणवत्ता संवर्द्धन %1$@ सेटिंग्स में डाउनलोड के लिए उपलब्ध हो सकते हैं।"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ulteriori voci e miglioramenti della qualità vocale possono essere disponibili per il download in Impostazioni di %1$@."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ulteriori voci e miglioramenti della qualità vocale possono essere disponibili per il download in Impostazioni di %1$@."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 설정에서 추가 음성 및 음성 품질 향상 기능을 다운로드할 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 설정에서 추가 음성 및 음성 품질 향상 기능을 다운로드할 수 있습니다."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дополнительные улучшения качества голоса и голоса могут быть доступны для загрузки в Настройках %1$@."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дополнительные улучшения качества голоса и голоса могут быть доступны для загрузки в Настройках %1$@."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Các giọng nói bổ sung và cải tiến chất lượng giọng nói có thể có sẵn để tải xuống trong Cài đặt %1$@."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các giọng nói bổ sung và cải tiến chất lượng giọng nói có thể có sẵn để tải xuống trong Cài đặt %1$@."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 设置中可以下载更多声音和语音质量增强功能。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 设置中可以下载更多声音和语音质量增强功能。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "其他語音和語音品質增強功能可在%1$@ 設定中下載。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他語音和語音品質增強功能可在%1$@ 設定中下載。"
           }
         }
       }
     },
-    "settings.cell.use_builtin_keyboard.title" : {
-      "comment" : "Option within Selection Mode settings to enable or disable using the system built-in keyboard.",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Built-in Keyboard"
+    "settings.cell.use_builtin_keyboard.title": {
+      "comment": "Option within Selection Mode settings to enable or disable using the system built-in keyboard.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Use Built-in Keyboard"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
Added a new setting that allows users to toggle the iOS built-in system keyboard on and off as their default keyboard method in Vocable AAC.

Key Changes

App Config & Persistence (AppConfig.swift)

Added isBuiltInKeyboardEnabled preference property in AppConfig and "isBuiltInKeyboardEnabled" key to UserDefaultsKey (defaults to false).
Selection Mode Settings UI (SelectionModeViewController.swift)

Added a "Use Built-in Keyboard" toggle cell in the Selection Mode settings screen.
Connected toggle state changes to AppConfig.isBuiltInKeyboardEnabled.
Text Editor Integration (TextEditorViewController.swift)

Configured TextEditorViewController to handle keyboard mode switching:
When Use Built-in Keyboard is ON: Hides Vocable's custom KeyboardView, makes OutputTextView editable and interactive, shows the iOS system software keyboard on screen load (becomeFirstResponder()), and synchronizes input via UITextViewDelegate with TextTransaction.
When Use Built-in Keyboard is OFF: Uses Vocable's custom gazeable KeyboardView.
Localization & Accessibility (Localizable.xcstrings, AccessibilityID)

Added localized string entries for settings.cell.use_builtin_keyboard.title across all supported locales.
Added accessibility identifier useBuiltInKeyboardToggle under .settings.selectionMode